### PR TITLE
feat(condition): add ability to write nested conditions

### DIFF
--- a/condition/condition.test.js
+++ b/condition/condition.test.js
@@ -154,3 +154,45 @@ test('source: store, if: literal, then: event, else: event', () => {
     ]
   `);
 });
+
+test('source: event, if: store, then: event, else: condition', () => {
+  const source = createEvent();
+  const target = createEvent();
+  const fn = jest.fn();
+  target.watch(fn);
+
+  condition({
+    source,
+    if: (value) => value < 2,
+    then: target.prepend((value) => `${value} < 2`),
+    else: condition({
+      if: (value) => value < 4,
+      then: target.prepend((value) => `2 <= ${value} < 4`),
+      else: target.prepend((value) => `4 <= ${value}`),
+    }),
+  });
+
+  source(1);
+  expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      "1 < 2",
+    ]
+  `);
+
+  source(3);
+  expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      "1 < 2",
+      "2 <= 3 < 4",
+    ]
+  `);
+
+  source(5);
+  expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      "1 < 2",
+      "2 <= 3 < 4",
+      "4 <= 5",
+    ]
+  `);
+});

--- a/condition/index.d.ts
+++ b/condition/index.d.ts
@@ -5,4 +5,4 @@ export function condition<State>(options: {
   if: Store<boolean> | ((payload: State) => boolean) | State;
   then?: Unit<State>;
   else?: Unit<State>;
-}): void;
+}): Unit<State>;

--- a/condition/index.js
+++ b/condition/index.js
@@ -7,7 +7,7 @@ const { is, guard, createEvent } = require('effector');
  * if — T
  */
 function condition({
-  source,
+  source = createEvent(),
   if: test,
   then: thenBranch = createEvent(),
   else: elseBranch = createEvent(),
@@ -26,6 +26,8 @@ function condition({
     filter: inverse(checker),
     target: elseBranch,
   });
+
+  return source;
 }
 
 function isFunction(value) {


### PR DESCRIPTION
Return `source` from `condition`, so it will be possible to write nested conditions:

```javascript
condition({
  source,
  if: condition1,
  then: unit1,
  else: condition({
    if: condition2,
    then: unit2,
    else: unit3,
  })
})
```