### PR TITLE
`throttle` method refactored, now supports only with object form

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -46,6 +46,7 @@
     "import/extensions": ["error", "ignorePackages"],
     "@typescript-eslint/no-use-before-define": "off",
     "unicorn/prefer-spread": "off",
-    "prefer-rest-params": "off"
+    "prefer-rest-params": "off",
+    "no-param-reassign": "off"
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,7 +31,7 @@
       }
     },
     {
-      "files": ["**/*.test.js"],
+      "files": ["**/*.test.js", "**/*.test.ts"],
       "env": {
         "jest": true
       },

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,4 +1,7 @@
 categories:
+  - title: '⚠️ Breaking changes'
+    label: 'BREAKING CHANGES'
+
   - title: '🚀 Features'
     labels:
       - 'feature'

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ import { throttle } from 'patronum/throttle';
 // You should call this event
 const trigger = createEvent<number>();
 
-const target = throttle(trigger, 200);
+const target = throttle({ source: trigger, timeout: 200 });
 
 target.watch((payload) => console.info('throttled', payload));
 

--- a/library.js
+++ b/library.js
@@ -1,18 +1,21 @@
 /* eslint-disable no-param-reassign */
 
-function defaultReader(part, target) {
-  if (part.sid) target.sid = part.sid;
-  if (part.name) target.name = part.name;
+function readProperties(part, target, properties) {
+  properties
+    .filter((name) => !!part[name])
+    .forEach((name) => {
+      target[name] = part[name];
+    });
 }
 
-const readConfig = (part, reader = defaultReader, target = {}) => {
+const readConfig = (part, properties, target = {}) => {
   if (typeof part !== 'object' || part === null) return target;
 
-  if (part.config) readConfig(part.config, reader, target);
+  if (part.config) readConfig(part.config, properties, target);
 
-  reader(part, target);
+  readProperties(part, target, properties);
 
-  if (part.ɔ) readConfig(part.ɔ, reader, target);
+  if (part.ɔ) readConfig(part.ɔ, properties, target);
 
   return target;
 };

--- a/library.js
+++ b/library.js
@@ -1,0 +1,20 @@
+/* eslint-disable no-param-reassign */
+
+function defaultReader(part, target) {
+  if (part.sid) target.sid = part.sid;
+  if (part.name) target.name = part.name;
+}
+
+const readConfig = (part, reader = defaultReader, target = {}) => {
+  if (typeof part !== 'object' || part === null) return target;
+
+  if (part.config) readConfig(part.config, reader, target);
+
+  reader(part, target);
+
+  if (part.ɔ) readConfig(part.ɔ, reader, target);
+
+  return target;
+};
+
+module.exports = { readConfig };

--- a/library.test.js
+++ b/library.test.js
@@ -1,0 +1,2 @@
+// https://t.me/effector_ru/129823
+test.todo('cover all variants with tests');

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     }
   },
   "dependencies": {
-    "effector-debounce": "^1.1.0",
-    "effector-throttle": "^1.1.0"
+    "effector-debounce": "^1.1.0"
   }
 }

--- a/throttle/index.d.ts
+++ b/throttle/index.d.ts
@@ -1,3 +1,7 @@
-import { createThrottle } from 'effector-throttle';
+import { Unit, Event } from 'effector';
 
-export const throttle = createThrottle;
+export function throttle<T>(_: {
+  source: Unit<T>;
+  timeout: number;
+  name?: string;
+}): Event<T>;

--- a/throttle/index.d.ts
+++ b/throttle/index.d.ts
@@ -5,3 +5,9 @@ export function throttle<T>(_: {
   timeout: number;
   name?: string;
 }): Event<T>;
+export function throttle<T, R extends Unit<T>>(_: {
+  source: Unit<T>;
+  timeout: number;
+  target: R;
+  name?: string;
+}): R;

--- a/throttle/index.js
+++ b/throttle/index.js
@@ -1,5 +1,42 @@
-const { createThrottle } = require('effector-throttle');
+const { is, createEffect, forward, createEvent, guard } = require('effector');
 
-module.exports = {
-  throttle: createThrottle,
-};
+function throttle({
+  source,
+  timeout,
+  name = source.shortName || 'unknown',
+  sid = `${source.sid}Z`,
+  loc,
+}) {
+  if (!is.unit(source))
+    throw new TypeError('callee must be unit from effector');
+  if (typeof timeout !== 'number' || timeout < 0)
+    throw new Error('timeout must be positive number or zero');
+
+  const tick = createEvent({
+    name: `${name}ThrottleTick`,
+    sid,
+    loc,
+  });
+
+  const timer = createEffect({
+    name: `${name}ThrottleTimer`,
+    loc,
+    handler: (payload) =>
+      new Promise((resolve) => setTimeout(resolve, timeout, payload)),
+  });
+
+  guard({
+    source,
+    filter: timer.pending.map((pending) => !pending),
+    target: timer,
+  });
+
+  forward({
+    from: timer.done.map(({ result }) => result),
+    to: tick,
+  });
+
+  return tick;
+}
+
+module.exports = { throttle };

--- a/throttle/index.js
+++ b/throttle/index.js
@@ -2,17 +2,13 @@ const { is, createEffect, forward, createEvent, guard } = require('effector');
 const { readConfig } = require('../library');
 
 function throttle(argument) {
-  const { source, timeout, sid, loc, name } = readConfig(
-    argument,
-    (part, target) => {
-      if (part.source) target.source = part.source;
-      if (part.timeout) target.timeout = part.timeout;
-
-      if (part.loc) target.loc = part.loc;
-      if (part.name) target.name = part.name;
-      if (part.sid) target.sid = part.sid;
-    },
-  );
+  const { source, timeout, sid, loc, name } = readConfig(argument, [
+    'source',
+    'timeout',
+    'loc',
+    'name',
+    'sid',
+  ]);
 
   if (!is.unit(source))
     throw new TypeError('callee must be unit from effector');

--- a/throttle/index.js
+++ b/throttle/index.js
@@ -1,25 +1,34 @@
 const { is, createEffect, forward, createEvent, guard } = require('effector');
+const { readConfig } = require('../library');
 
-function throttle({
-  source,
-  timeout,
-  name = source.shortName || 'unknown',
-  sid = `${source.sid}Z`,
-  loc,
-}) {
+function throttle(argument) {
+  const { source, timeout, sid, loc, name } = readConfig(
+    argument,
+    (part, target) => {
+      if (part.source) target.source = part.source;
+      if (part.timeout) target.timeout = part.timeout;
+
+      if (part.loc) target.loc = part.loc;
+      if (part.name) target.name = part.name;
+      if (part.sid) target.sid = part.sid;
+    },
+  );
+
   if (!is.unit(source))
     throw new TypeError('callee must be unit from effector');
   if (typeof timeout !== 'number' || timeout < 0)
     throw new Error('timeout must be positive number or zero');
 
+  const actualName = name || source.shortName || 'unknown';
+
   const tick = createEvent({
-    name: `${name}ThrottleTick`,
-    sid,
+    name: `${actualName}ThrottleTick`,
     loc,
   });
 
   const timer = createEffect({
-    name: `${name}ThrottleTimer`,
+    name: `${actualName}ThrottleTimer`,
+    sid,
     loc,
     handler: (payload) =>
       new Promise((resolve) => setTimeout(resolve, timeout, payload)),

--- a/throttle/index.js
+++ b/throttle/index.js
@@ -1,4 +1,4 @@
-const { is, createEffect, forward, createEvent, guard } = require('effector');
+const { createEffect, createEvent, guard, is, sample } = require('effector');
 const { readConfig } = require('../library');
 
 function throttle(argument) {
@@ -40,9 +40,10 @@ function throttle(argument) {
     target: timer,
   });
 
-  forward({
-    from: timer.done.map(({ result }) => result),
-    to: tick,
+  sample({
+    source,
+    clock: timer.done.map(({ result }) => result),
+    target: tick,
   });
 
   return tick;

--- a/throttle/index.js
+++ b/throttle/index.js
@@ -2,9 +2,11 @@ const { is, createEffect, forward, createEvent, guard } = require('effector');
 const { readConfig } = require('../library');
 
 function throttle(argument) {
-  const { source, timeout, sid, loc, name } = readConfig(argument, [
+  const { source, timeout, target, sid, loc, name } = readConfig(argument, [
     'source',
     'timeout',
+    'target',
+
     'loc',
     'name',
     'sid',
@@ -17,10 +19,12 @@ function throttle(argument) {
 
   const actualName = name || source.shortName || 'unknown';
 
-  const tick = createEvent({
-    name: `${actualName}ThrottleTick`,
-    loc,
-  });
+  const tick =
+    target ||
+    createEvent({
+      name: `${actualName}ThrottleTick`,
+      loc,
+    });
 
   const timer = createEffect({
     name: `${actualName}ThrottleTimer`,

--- a/throttle/readme.md
+++ b/throttle/readme.md
@@ -17,7 +17,7 @@ const someHappened = createEvent<number>();
 Create throttled event from it:
 
 ```ts
-import { throttle } from 'effector-throttle';
+import { throttle } from 'patronum/throttle';
 
 const THROTTLE_TIMEOUT_IN_MS = 200;
 
@@ -44,13 +44,13 @@ Also you can use `Effect` and `Store` as trigger. `throttle` always returns `Eve
 
 ```ts
 const event = createEvent<number>();
-const debouncedEvent: Event<number> = throttle({ source: event, timeout: 100 });
+const throttledEvent: Event<number> = throttle({ source: event, timeout: 100 });
 
 const fx = createEffect<number, void>();
-const debouncedEffect: Event<number> = throttle({ source: fx, timeout: 100 });
+const throttledEffect: Event<number> = throttle({ source: fx, timeout: 100 });
 
 const $store = createStore<number>(0);
-const debouncedStore: Event<number> = throttle({
+const throttledStore: Event<number> = throttle({
   source: $store,
   timeout: 100,
 });

--- a/throttle/readme.md
+++ b/throttle/readme.md
@@ -46,6 +46,9 @@ someHappened(1);
 someHappened(2);
 someHappened(3);
 someHappened(4);
+
+// after 200 ms after first call
+// => someHappened now 4
 ```
 
 Also you can use `Effect` and `Store` as trigger. `throttle` always returns `Event`:
@@ -84,4 +87,10 @@ $dumped.watch((payload) => {
 });
 
 throttle({ source: $source, timeout: 40, target: $dumped });
+
+change();
+change();
+change();
+
+// after 40ms after first call, 3 will be saved to localStorage
 ```

--- a/throttle/readme.md
+++ b/throttle/readme.md
@@ -4,7 +4,15 @@
 import { throttle } from 'patronum/throttle';
 ```
 
-## Usage
+## `throttle({ source, timeout })`
+
+### Formulae
+
+```ts
+result = throttle({ source, timeout });
+```
+
+### Usage
 
 Create event that should be throttled:
 
@@ -54,4 +62,26 @@ const throttledStore: Event<number> = throttle({
   source: $store,
   timeout: 100,
 });
+```
+
+## `throttle({ source, timeout, target })`
+
+### Formulae
+
+```ts
+throttle({ source, timeout, target });
+```
+
+### Usage
+
+```ts
+const change = createEvent();
+const $source = createStore(0).on(change, (state) => state + 1);
+
+const $dumped = createStore(0);
+$dumped.watch((payload) => {
+  localStorage.setItem('dump', JSON.stringify(payload));
+});
+
+throttle({ source: $source, timeout: 40, target: $dumped });
 ```

--- a/throttle/readme.md
+++ b/throttle/readme.md
@@ -4,17 +4,32 @@
 import { throttle } from 'patronum/throttle';
 ```
 
-## Example
+## Usage
+
+Create event that should be throttled:
 
 ```ts
 import { createEvent } from 'effector';
-import { throttle } from 'patronum/throttle';
+
+const someHappened = createEvent<number>();
+```
+
+Create throttled event from it:
+
+```ts
+import { throttle } from 'effector-throttle';
 
 const THROTTLE_TIMEOUT_IN_MS = 200;
 
-const someHappened = createEvent<number>();
-const throttled = createThrottle(someHappened, THROTTLE_TIMEOUT_IN_MS);
+const throttled = throttle({
+  source: someHappened,
+  timeout: THROTTLE_TIMEOUT_IN_MS,
+});
+```
 
+When you call `someHappened` it will make throttled call the `throttled` event:
+
+```ts
 throttled.watch((payload) => {
   console.info('someHappened now', payload);
 });
@@ -23,4 +38,20 @@ someHappened(1);
 someHappened(2);
 someHappened(3);
 someHappened(4);
+```
+
+Also you can use `Effect` and `Store` as trigger. `throttle` always returns `Event`:
+
+```ts
+const event = createEvent<number>();
+const debouncedEvent: Event<number> = throttle({ source: event, timeout: 100 });
+
+const fx = createEffect<number, void>();
+const debouncedEffect: Event<number> = throttle({ source: fx, timeout: 100 });
+
+const $store = createStore<number>(0);
+const debouncedStore: Event<number> = throttle({
+  source: $store,
+  timeout: 100,
+});
 ```

--- a/throttle/throttle.fork.test.ts
+++ b/throttle/throttle.fork.test.ts
@@ -1,0 +1,104 @@
+import 'regenerator-runtime/runtime';
+import { createDomain } from 'effector';
+import { fork, serialize, allSettled } from 'effector/fork';
+import { throttle } from '.';
+
+test('throttle works in forked scope', async () => {
+  const app = createDomain();
+  const $counter = app.createStore(0);
+
+  const trigger = app.createEvent();
+
+  const throttled = throttle({ source: trigger, timeout: 40 });
+
+  $counter.on(throttled, (value) => value + 1);
+
+  const scope = fork(app);
+
+  await allSettled(trigger, {
+    scope,
+    params: undefined,
+  });
+
+  expect(serialize(scope)).toMatchInlineSnapshot(`
+    Object {
+      "9tnuk9": 1,
+    }
+  `);
+});
+
+test('throttle do not affect another forks', async () => {
+  const app = createDomain();
+  const $counter = app.createStore(0);
+
+  const trigger = app.createEvent<number>();
+
+  const throttled = throttle({ source: trigger, timeout: 40 });
+
+  $counter.on(throttled, (value, payload) => value + payload);
+
+  const scopeA = fork(app);
+  const scopeB = fork(app);
+
+  await allSettled(trigger, {
+    scope: scopeA,
+    params: 1,
+  });
+
+  await allSettled(trigger, {
+    scope: scopeB,
+    params: 100,
+  });
+
+  await allSettled(trigger, {
+    scope: scopeA,
+    params: 1,
+  });
+
+  await allSettled(trigger, {
+    scope: scopeB,
+    params: 100,
+  });
+
+  expect(serialize(scopeA)).toMatchInlineSnapshot(`
+    Object {
+      "l2rydu": 2,
+    }
+  `);
+
+  expect(serialize(scopeB)).toMatchInlineSnapshot(`
+    Object {
+      "l2rydu": 200,
+    }
+  `);
+});
+
+test('throttle do not affect original store value', async () => {
+  const app = createDomain();
+  const $counter = app.createStore(0);
+  const trigger = app.createEvent<number>();
+
+  const throttled = throttle({ source: trigger, timeout: 40 });
+
+  $counter.on(throttled, (value, payload) => value + payload);
+
+  const scope = fork(app);
+
+  await allSettled(trigger, {
+    scope,
+    params: 1,
+  });
+
+  await allSettled(trigger, {
+    scope,
+    params: 1,
+  });
+
+  expect(serialize(scope)).toMatchInlineSnapshot(`
+    Object {
+      "bliro0": 2,
+    }
+  `);
+
+  expect($counter.getState()).toMatchInlineSnapshot(`0`);
+});

--- a/throttle/throttle.fork.test.ts
+++ b/throttle/throttle.fork.test.ts
@@ -5,24 +5,24 @@ import { throttle } from '.';
 
 test('throttle works in forked scope', async () => {
   const app = createDomain();
+  const source = app.createEvent();
+
   const $counter = app.createStore(0);
 
-  const trigger = app.createEvent();
-
-  const throttled = throttle({ source: trigger, timeout: 40 });
+  const throttled = throttle({ source, timeout: 40 });
 
   $counter.on(throttled, (value) => value + 1);
 
   const scope = fork(app);
 
-  await allSettled(trigger, {
+  await allSettled(source, {
     scope,
     params: undefined,
   });
 
   expect(serialize(scope)).toMatchInlineSnapshot(`
     Object {
-      "9tnuk9": 1,
+      "-983uum": 1,
     }
   `);
 });

--- a/throttle/throttle.test.ts
+++ b/throttle/throttle.test.ts
@@ -53,7 +53,7 @@ describe('event', () => {
     expect(watcher).toBeCalledTimes(2);
   });
 
-  test('throttled event triggered with first value', async () => {
+  test('throttled event triggered with latest value', async () => {
     const watcher = jest.fn();
 
     const trigger = createEvent<number>();
@@ -72,7 +72,7 @@ describe('event', () => {
     expect(watcher.mock.calls).toMatchInlineSnapshot(`
       Array [
         Array [
-          0,
+          2,
         ],
       ]
     `);
@@ -97,7 +97,7 @@ describe('event', () => {
     expect(watcher.mock.calls).toMatchInlineSnapshot(`
       Array [
         Array [
-          0,
+          2,
         ],
       ]
     `);
@@ -110,10 +110,10 @@ describe('event', () => {
     expect(watcher.mock.calls).toMatchInlineSnapshot(`
       Array [
         Array [
-          0,
+          2,
         ],
         Array [
-          3,
+          4,
         ],
       ]
     `);
@@ -200,7 +200,7 @@ describe('effect', () => {
     expect(watcher).toBeCalledTimes(2);
   });
 
-  test('throttle effect triggered with last value', async () => {
+  test('throttle effect triggered with latest value', async () => {
     const watcher = jest.fn();
 
     const trigger = createEffect<number, void>().use(() => undefined);
@@ -220,7 +220,7 @@ describe('effect', () => {
     expect(watcher.mock.calls).toMatchInlineSnapshot(`
       Array [
         Array [
-          0,
+          2,
         ],
       ]
     `);
@@ -243,7 +243,7 @@ describe('effect', () => {
     await wait(40);
 
     expect(watcher).toBeCalledTimes(1);
-    expect(watcher).toBeCalledWith(0);
+    expect(watcher).toBeCalledWith(2);
 
     trigger(3);
     await wait(30);
@@ -255,10 +255,10 @@ describe('effect', () => {
     expect(watcher.mock.calls).toMatchInlineSnapshot(`
       Array [
         Array [
-          0,
+          2,
         ],
         Array [
-          3,
+          4,
         ],
       ]
     `);
@@ -286,7 +286,7 @@ describe('effect', () => {
     expect(watcher.mock.calls).toMatchInlineSnapshot(`
       Array [
         Array [
-          0,
+          2,
         ],
       ]
     `);
@@ -314,7 +314,7 @@ describe('effect', () => {
     expect(watcher.mock.calls).toMatchInlineSnapshot(`
       Array [
         Array [
-          0,
+          2,
         ],
       ]
     `);
@@ -369,7 +369,7 @@ describe('store', () => {
     expect(watcher.mock.calls).toMatchInlineSnapshot(`
       Array [
         Array [
-          1,
+          2,
         ],
       ]
     `);
@@ -401,7 +401,7 @@ describe('store', () => {
           0,
         ],
         Array [
-          1,
+          3,
         ],
       ]
     `);
@@ -529,12 +529,12 @@ test('source event, target effect', async () => {
 
   expect(watcher).toBeCalledTimes(1);
   expect(watcher.mock.calls).toMatchInlineSnapshot(`
+    Array [
       Array [
-        Array [
-          0,
-        ],
-      ]
-    `);
+        2,
+      ],
+    ]
+  `);
 });
 
 test('source store, target effect', async () => {
@@ -558,10 +558,10 @@ test('source store, target effect', async () => {
 
   expect(watcher).toBeCalledTimes(1);
   expect(watcher.mock.calls).toMatchInlineSnapshot(`
+    Array [
       Array [
-        Array [
-          1,
-        ],
-      ]
-    `);
+        3,
+      ],
+    ]
+  `);
 });

--- a/throttle/throttle.test.ts
+++ b/throttle/throttle.test.ts
@@ -1,5 +1,11 @@
 import 'regenerator-runtime/runtime';
-import { createStore, createEvent, createEffect, createDomain } from 'effector';
+import {
+  createStore,
+  createEvent,
+  createEffect,
+  createDomain,
+  is,
+} from 'effector';
 import { throttle } from '.';
 
 const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -111,6 +117,36 @@ describe('event', () => {
         ],
       ]
     `);
+  });
+
+  test('throttle call target', async () => {
+    const watcher = jest.fn();
+
+    const source = createEvent();
+    const target = createEvent();
+
+    throttle({ source, timeout: 40, target });
+
+    target.watch(watcher);
+
+    source();
+    source();
+    source();
+
+    expect(watcher).not.toBeCalled();
+
+    await wait(40);
+
+    expect(watcher).toBeCalledTimes(1);
+  });
+
+  test('throttle with target returns target', async () => {
+    const source = createEvent();
+    const target = createEvent();
+
+    const result = throttle({ source, timeout: 40, target });
+
+    expect(result).toBe(target);
   });
 
   test('name correctly assigned from trigger', () => {
@@ -228,6 +264,76 @@ describe('effect', () => {
     `);
   });
 
+  test('throttle call target effect', async () => {
+    const watcher = jest.fn();
+
+    const source = createEvent<number>();
+    const target = createEffect<number, void>().use(() => undefined);
+
+    throttle({ source, timeout: 40, target });
+
+    target.watch(watcher);
+
+    source(0);
+    source(1);
+    source(2);
+
+    expect(watcher).not.toBeCalled();
+
+    await wait(40);
+
+    expect(watcher).toBeCalledTimes(1);
+    expect(watcher.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          0,
+        ],
+      ]
+    `);
+  });
+
+  test('source effect, target effect', async () => {
+    const watcher = jest.fn();
+
+    const source = createEffect<number, void>().use(() => undefined);
+    const target = createEffect<number, void>().use(() => undefined);
+
+    throttle({ source, timeout: 40, target });
+
+    target.watch(watcher);
+
+    source(0);
+    source(1);
+    source(2);
+
+    expect(watcher).not.toBeCalled();
+
+    await wait(40);
+
+    expect(watcher).toBeCalledTimes(1);
+    expect(watcher.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          0,
+        ],
+      ]
+    `);
+  });
+
+  test('throttle with target returns target', async () => {
+    const source = createEvent();
+    const target = createEffect<void, void>({
+      handler() {
+        /* */
+      },
+    });
+
+    const result = throttle({ source, timeout: 40, target });
+
+    expect(result).toBe(target);
+    expect(is.effect(result)).toBe(true);
+  });
+
   test('name correctly assigned from trigger', () => {
     const demoFx = createEffect();
     const throttledDemo = throttle({ source: demoFx, timeout: 20 });
@@ -267,6 +373,48 @@ describe('store', () => {
         ],
       ]
     `);
+  });
+
+  test('source store, target store', async () => {
+    const watcher = jest.fn();
+
+    const change = createEvent();
+
+    const source = createStore(0).on(change, (state) => state + 1);
+    const target = createStore(0);
+
+    throttle({ source, timeout: 40, target });
+
+    target.watch(watcher);
+
+    change();
+    change();
+    change();
+
+    expect(watcher).toBeCalledTimes(1);
+
+    await wait(40);
+
+    expect(watcher.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          0,
+        ],
+        Array [
+          1,
+        ],
+      ]
+    `);
+  });
+
+  test('throttle with target returns target', async () => {
+    const source = createEvent<number>();
+    const target = createStore(0);
+
+    const result = throttle({ source, timeout: 40, target });
+
+    expect(result).toBe(target);
+    expect(is.store(result)).toBe(true);
   });
 
   test('name correctly assigned from trigger', () => {
@@ -359,4 +507,61 @@ test('name should not be in domain', () => {
   const throttledDemo = throttle({ source: event, timeout: 20 });
 
   expect(throttledDemo.shortName).toMatchInlineSnapshot(`"eventThrottleTick"`);
+});
+
+test('source event, target effect', async () => {
+  const watcher = jest.fn();
+
+  const source = createEvent<number>();
+  const target = createEffect<number, void>().use(() => undefined);
+
+  throttle({ source, timeout: 40, target });
+
+  target.watch(watcher);
+
+  source(0);
+  source(1);
+  source(2);
+
+  expect(watcher).not.toBeCalled();
+
+  await wait(40);
+
+  expect(watcher).toBeCalledTimes(1);
+  expect(watcher.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          0,
+        ],
+      ]
+    `);
+});
+
+test('source store, target effect', async () => {
+  const watcher = jest.fn();
+
+  const change = createEvent();
+  const source = createStore<number>(0).on(change, (state) => state + 1);
+  const target = createEffect<number, void>().use(() => undefined);
+
+  throttle({ source, timeout: 40, target });
+
+  target.watch(watcher);
+
+  change();
+  change();
+  change();
+
+  expect(watcher).not.toBeCalled();
+
+  await wait(40);
+
+  expect(watcher).toBeCalledTimes(1);
+  expect(watcher.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          1,
+        ],
+      ]
+    `);
 });

--- a/throttle/throttle.test.ts
+++ b/throttle/throttle.test.ts
@@ -1,0 +1,362 @@
+import 'regenerator-runtime/runtime';
+import { createStore, createEvent, createEffect, createDomain } from 'effector';
+import { throttle } from '.';
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe('event', () => {
+  test('throttle event', async () => {
+    const watcher = jest.fn();
+
+    const trigger = createEvent();
+    const throttled = throttle({ source: trigger, timeout: 40 });
+
+    throttled.watch(watcher);
+
+    trigger();
+    trigger();
+    trigger();
+
+    expect(watcher).not.toBeCalled();
+
+    await wait(40);
+
+    expect(watcher).toBeCalledTimes(1);
+  });
+
+  test('throttled event with wait', async () => {
+    const watcher = jest.fn();
+
+    const trigger = createEvent();
+    const throttled = throttle({ source: trigger, timeout: 40 });
+
+    throttled.watch(watcher);
+
+    trigger();
+
+    await wait(30);
+    trigger();
+
+    await wait(30);
+    trigger();
+
+    expect(watcher).toBeCalled();
+
+    await wait(40);
+
+    expect(watcher).toBeCalledTimes(2);
+  });
+
+  test('throttled event triggered with first value', async () => {
+    const watcher = jest.fn();
+
+    const trigger = createEvent<number>();
+    const throttled = throttle({ source: trigger, timeout: 40 });
+
+    throttled.watch(watcher);
+
+    trigger(0);
+    trigger(1);
+    trigger(2);
+
+    expect(watcher).not.toBeCalled();
+
+    await wait(40);
+
+    expect(watcher.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          0,
+        ],
+      ]
+    `);
+  });
+
+  test('throttled event works after trigger', async () => {
+    const watcher = jest.fn();
+
+    const trigger = createEvent<number>();
+    const throttled = throttle({ source: trigger, timeout: 40 });
+
+    throttled.watch(watcher);
+
+    trigger(0);
+    trigger(1);
+    trigger(2);
+
+    expect(watcher).not.toBeCalled();
+
+    await wait(40);
+
+    expect(watcher.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          0,
+        ],
+      ]
+    `);
+
+    trigger(3);
+    await wait(30);
+    trigger(4);
+    await wait(50);
+
+    expect(watcher.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          0,
+        ],
+        Array [
+          3,
+        ],
+      ]
+    `);
+  });
+
+  test('name correctly assigned from trigger', () => {
+    const demo = createEvent();
+    const throttledDemo = throttle({ source: demo, timeout: 20 });
+
+    expect(throttledDemo.shortName).toMatchInlineSnapshot(`"demoThrottleTick"`);
+  });
+});
+
+describe('effect', () => {
+  test('throttle effect', async () => {
+    const watcher = jest.fn();
+
+    const trigger = createEffect<void, void>().use(() => undefined);
+    const throttled = throttle({ source: trigger, timeout: 40 });
+
+    throttled.watch(watcher);
+
+    trigger();
+    trigger();
+    trigger();
+
+    expect(watcher).not.toBeCalled();
+
+    await wait(40);
+
+    expect(watcher).toBeCalledTimes(1);
+  });
+
+  test('throttle effect with wait', async () => {
+    const watcher = jest.fn();
+
+    const trigger = createEffect<void, void>().use(() => undefined);
+    const throttled = throttle({ source: trigger, timeout: 40 });
+
+    throttled.watch(watcher);
+
+    trigger();
+
+    await wait(30);
+    trigger();
+
+    await wait(30);
+    trigger();
+
+    expect(watcher).toBeCalledTimes(1);
+
+    await wait(40);
+
+    expect(watcher).toBeCalledTimes(2);
+  });
+
+  test('throttle effect triggered with last value', async () => {
+    const watcher = jest.fn();
+
+    const trigger = createEffect<number, void>().use(() => undefined);
+    const throttled = throttle({ source: trigger, timeout: 40 });
+
+    throttled.watch(watcher);
+
+    trigger(0);
+    trigger(1);
+    trigger(2);
+
+    expect(watcher).not.toBeCalled();
+
+    await wait(40);
+
+    expect(watcher).toBeCalledTimes(1);
+    expect(watcher.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          0,
+        ],
+      ]
+    `);
+  });
+
+  test('throttled effect works after trigger', async () => {
+    const watcher = jest.fn();
+
+    const trigger = createEffect<number, void>().use(() => undefined);
+    const throttled = throttle({ source: trigger, timeout: 40 });
+
+    throttled.watch(watcher);
+
+    trigger(0);
+    trigger(1);
+    trigger(2);
+
+    expect(watcher).not.toBeCalled();
+
+    await wait(40);
+
+    expect(watcher).toBeCalledTimes(1);
+    expect(watcher).toBeCalledWith(0);
+
+    trigger(3);
+    await wait(30);
+    trigger(4);
+
+    await wait(50);
+
+    expect(watcher).toBeCalledTimes(2);
+    expect(watcher.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          0,
+        ],
+        Array [
+          3,
+        ],
+      ]
+    `);
+  });
+
+  test('name correctly assigned from trigger', () => {
+    const demoFx = createEffect();
+    const throttledDemo = throttle({ source: demoFx, timeout: 20 });
+
+    expect(throttledDemo.shortName).toMatchInlineSnapshot(
+      `"demoFxThrottleTick"`,
+    );
+  });
+});
+
+describe('store', () => {
+  test('throttle store and pass values', async () => {
+    const watcher = jest.fn();
+
+    const trigger = createEvent<number>();
+    const $store = createStore(0);
+
+    $store.on(trigger, (_, value) => value);
+
+    const throttled = throttle({ source: $store, timeout: 40 });
+
+    throttled.watch(watcher);
+
+    trigger(0);
+    trigger(1);
+    trigger(2);
+
+    expect(watcher).not.toBeCalled();
+
+    await wait(40);
+
+    expect(watcher).toBeCalledTimes(1);
+    expect(watcher.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          1,
+        ],
+      ]
+    `);
+  });
+
+  test('name correctly assigned from trigger', () => {
+    const $demo = createStore(0);
+    const throttledDemo = throttle({ source: $demo, timeout: 20 });
+
+    expect(throttledDemo.shortName).toMatchInlineSnapshot(
+      `"$demoThrottleTick"`,
+    );
+  });
+});
+
+test('debounce do not affect another instance', async () => {
+  const watcherFirst = jest.fn();
+  const triggerFirst = createEvent<number>();
+  const throttledFirst = throttle({ source: triggerFirst, timeout: 20 });
+  throttledFirst.watch(watcherFirst);
+
+  const watcherSecond = jest.fn();
+  const triggerSecond = createEvent<string>();
+  const throttledSecond = throttle({ source: triggerSecond, timeout: 60 });
+  throttledSecond.watch(watcherSecond);
+
+  triggerFirst(0);
+
+  expect(watcherFirst).not.toBeCalled();
+  await wait(20);
+
+  expect(watcherFirst).toBeCalledTimes(1);
+  expect(watcherFirst.mock.calls).toMatchInlineSnapshot(`
+    Array [
+      Array [
+        0,
+      ],
+    ]
+  `);
+
+  expect(watcherSecond).not.toBeCalled();
+
+  triggerSecond('foo');
+  triggerFirst(1);
+  await wait(20);
+  triggerFirst(2);
+  await wait(20);
+
+  expect(watcherFirst).toBeCalledTimes(3);
+  expect(watcherFirst.mock.calls).toMatchInlineSnapshot(`
+    Array [
+      Array [
+        0,
+      ],
+      Array [
+        1,
+      ],
+      Array [
+        2,
+      ],
+    ]
+  `);
+  expect(watcherSecond).not.toBeCalled();
+
+  await wait(20);
+
+  expect(watcherSecond).toBeCalledTimes(1);
+  expect(watcherSecond.mock.calls).toMatchInlineSnapshot(`
+    Array [
+      Array [
+        "foo",
+      ],
+    ]
+  `);
+});
+
+test('name correctly assigned from params', () => {
+  const demo = createEvent();
+  const throttledDemo = throttle({
+    source: demo,
+    timeout: 20,
+    name: 'Example',
+  });
+
+  expect(throttledDemo.shortName).toMatchInlineSnapshot(
+    `"ExampleThrottleTick"`,
+  );
+});
+
+test('name should not be in domain', () => {
+  const domain = createDomain();
+  const event = domain.createEvent();
+  const throttledDemo = throttle({ source: event, timeout: 20 });
+
+  expect(throttledDemo.shortName).toMatchInlineSnapshot(`"eventThrottleTick"`);
+});

--- a/throttle/throttle.test.ts
+++ b/throttle/throttle.test.ts
@@ -279,7 +279,7 @@ describe('store', () => {
   });
 });
 
-test('debounce do not affect another instance', async () => {
+test('throttle do not affect another instance', async () => {
   const watcherFirst = jest.fn();
   const triggerFirst = createEvent<number>();
   const throttledFirst = throttle({ source: triggerFirst, timeout: 20 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2791,11 +2791,6 @@ effector-debounce@^1.1.0:
   resolved "https://registry.yarnpkg.com/effector-debounce/-/effector-debounce-1.1.0.tgz#e6aa74efd302d480f57b2e945e71ab34772ba360"
   integrity sha512-UfJLUQx2fIjNIGx9kmPvmCjClInXvJP+jmREpVMamLQkEoMw3PqdnzoLUqFPJQI/tXGD9LQ1OYrL9eANVpIAtg==
 
-effector-throttle@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/effector-throttle/-/effector-throttle-1.1.0.tgz#8d3b4b7c24ed60be746fdfdfc2bf627f0c9f6983"
-  integrity sha512-hkFwr8W6QZMnvxb8XIqwFyQQCT4kwzHV2eaoVCGfRSixwPs0GrTcZIrXTg03pTHRLXn+4x2owRD/OXoAfTQTYQ==
-
 effector@^20.7.0:
   version "20.15.9"
   resolved "https://registry.yarnpkg.com/effector/-/effector-20.15.9.tgz#488a738c5d02653808f160ab99a29f8ce9afb869"


### PR DESCRIPTION
BREAKING CHANGE: unnamed arguments removed, supports only object form, pass payload from the latest `source` trigger

closes #25

```ts
const throttled = throttle({ source: unit, timeout: 200 })

throttled.watch(payload => console.log("triggered", payload))

unit(1)
unit(2)
unit(3)

// after 200ms
// => triggered 1
```

```ts
throttle({
  source, timeout: 200, target
})
```