### PR TITLE
Fully refactored `debounce` method (object form arguments, pass latest value, supports target)

### DIFF
--- a/debounce/debounce.fork.test.ts
+++ b/debounce/debounce.fork.test.ts
@@ -1,0 +1,104 @@
+import 'regenerator-runtime/runtime';
+import { createDomain } from 'effector';
+import { fork, serialize, allSettled } from 'effector/fork';
+import { debounce } from '.';
+
+test('debounce works in forked scope', async () => {
+  const app = createDomain();
+  const $counter = app.createStore(0);
+
+  const trigger = app.createEvent();
+
+  const debounced = debounce({ source: trigger, timeout: 40 });
+
+  $counter.on(debounced, (value) => value + 1);
+
+  const scope = fork(app);
+
+  await allSettled(trigger, {
+    scope,
+    params: undefined,
+  });
+
+  expect(serialize(scope)).toMatchInlineSnapshot(`
+    Object {
+      "5fqfmh": 1,
+    }
+  `);
+});
+
+test('debounce do not affect another forks', async () => {
+  const app = createDomain();
+  const $counter = app.createStore(0);
+
+  const trigger = app.createEvent<number>();
+
+  const debounced = debounce({ source: trigger, timeout: 40 });
+
+  $counter.on(debounced, (value, payload) => value + payload);
+
+  const scopeA = fork(app);
+  const scopeB = fork(app);
+
+  await allSettled(trigger, {
+    scope: scopeA,
+    params: 1,
+  });
+
+  await allSettled(trigger, {
+    scope: scopeB,
+    params: 100,
+  });
+
+  await allSettled(trigger, {
+    scope: scopeA,
+    params: 1,
+  });
+
+  await allSettled(trigger, {
+    scope: scopeB,
+    params: 100,
+  });
+
+  expect(serialize(scopeA)).toMatchInlineSnapshot(`
+    Object {
+      "r5878y": 2,
+    }
+  `);
+
+  expect(serialize(scopeB)).toMatchInlineSnapshot(`
+    Object {
+      "r5878y": 200,
+    }
+  `);
+});
+
+test('debounce do not affect original store value', async () => {
+  const app = createDomain();
+  const $counter = app.createStore(0);
+  const trigger = app.createEvent<number>();
+
+  const debounced = debounce({ source: trigger, timeout: 40 });
+
+  $counter.on(debounced, (value, payload) => value + payload);
+
+  const scope = fork(app);
+
+  await allSettled(trigger, {
+    scope,
+    params: 1,
+  });
+
+  await allSettled(trigger, {
+    scope,
+    params: 1,
+  });
+
+  expect(serialize(scope)).toMatchInlineSnapshot(`
+    Object {
+      "hnz0j4": 2,
+    }
+  `);
+
+  expect($counter.getState()).toMatchInlineSnapshot(`0`);
+});

--- a/debounce/debounce.test.ts
+++ b/debounce/debounce.test.ts
@@ -1,0 +1,439 @@
+import 'regenerator-runtime/runtime';
+import { createStore, createEvent, createEffect, createDomain } from 'effector';
+import { debounce } from '.';
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe('event', () => {
+  test('debounce event', async () => {
+    const watcher = jest.fn();
+
+    const trigger = createEvent();
+    const debounced = debounce({ source: trigger, timeout: 40 });
+
+    debounced.watch(watcher);
+
+    trigger();
+    trigger();
+    trigger();
+
+    expect(watcher).not.toBeCalled();
+
+    await wait(40);
+
+    expect(watcher).toBeCalledTimes(1);
+  });
+
+  test('debounce event with wait', async () => {
+    const watcher = jest.fn();
+
+    const trigger = createEvent();
+    const debounced = debounce({ source: trigger, timeout: 40 });
+
+    debounced.watch(watcher);
+
+    trigger();
+
+    await wait(30);
+    trigger();
+
+    await wait(30);
+    trigger();
+
+    expect(watcher).not.toBeCalled();
+
+    await wait(40);
+
+    expect(watcher).toBeCalledTimes(1);
+  });
+
+  test('debounced event triggered with last value', async () => {
+    const watcher = jest.fn();
+
+    const trigger = createEvent<number>();
+    const debounced = debounce({ source: trigger, timeout: 40 });
+
+    debounced.watch(watcher);
+
+    trigger(0);
+    trigger(1);
+    trigger(2);
+
+    expect(watcher).not.toBeCalled();
+
+    await wait(40);
+
+    expect(watcher).toBeCalledTimes(1);
+    expect(watcher).toBeCalledWith(2);
+  });
+
+  test('debounced event works after trigger', async () => {
+    const watcher = jest.fn();
+
+    const trigger = createEvent<number>();
+    const debounced = debounce({ source: trigger, timeout: 40 });
+
+    debounced.watch(watcher);
+
+    trigger(0);
+    trigger(1);
+    trigger(2);
+
+    expect(watcher).not.toBeCalled();
+
+    await wait(40);
+
+    trigger(3);
+    await wait(30);
+    trigger(4);
+
+    await wait(40);
+
+    expect(watcher).toBeCalledTimes(2);
+    expect(watcher).toBeCalledWith(2);
+    expect(watcher).toBeCalledWith(4);
+  });
+
+  test('calls target', async () => {
+    const watcher = jest.fn();
+
+    const source = createEvent<number>();
+    const target = createEvent<number>();
+
+    debounce({ source, timeout: 40, target });
+
+    target.watch(watcher);
+
+    source(1);
+    source(2);
+    source(3);
+
+    expect(watcher).not.toBeCalled();
+
+    await wait(40);
+
+    expect(watcher).toBeCalledTimes(1);
+    expect(watcher).toBeCalledWith(3);
+  });
+
+  test('with target returns target', async () => {
+    const source = createEvent();
+    const target = createEvent();
+
+    const result = debounce({ source, timeout: 40, target });
+
+    expect(result).toBe(target);
+  });
+
+  test('name correctly assigned from trigger', () => {
+    const demo = createEvent();
+    const debouncedDemo = debounce({ source: demo, timeout: 20 });
+
+    expect(debouncedDemo.shortName).toMatchInlineSnapshot(`"demoDebounceTick"`);
+  });
+});
+
+describe('effect', () => {
+  test('debounce effect', async () => {
+    const watcher = jest.fn();
+
+    const trigger = createEffect<void, void>().use(() => undefined);
+    const debounced = debounce({ source: trigger, timeout: 40 });
+
+    debounced.watch(watcher);
+
+    trigger();
+    trigger();
+    trigger();
+
+    expect(watcher).not.toBeCalled();
+
+    await wait(40);
+
+    expect(watcher).toBeCalledTimes(1);
+  });
+
+  test('debounce effect with wait', async () => {
+    const watcher = jest.fn();
+
+    const trigger = createEffect<void, void>().use(() => undefined);
+    const debounced = debounce({ source: trigger, timeout: 40 });
+
+    debounced.watch(watcher);
+
+    trigger();
+
+    await wait(30);
+    trigger();
+
+    await wait(30);
+    trigger();
+
+    expect(watcher).not.toBeCalled();
+
+    await wait(40);
+
+    expect(watcher).toBeCalledTimes(1);
+  });
+
+  test('debounced effect triggered with last value', async () => {
+    const watcher = jest.fn();
+
+    const trigger = createEffect<number, void>().use(() => undefined);
+    const debounced = debounce({ source: trigger, timeout: 40 });
+
+    debounced.watch(watcher);
+
+    trigger(0);
+    trigger(1);
+    trigger(2);
+
+    expect(watcher).not.toBeCalled();
+
+    await wait(40);
+
+    expect(watcher).toBeCalledTimes(1);
+    expect(watcher).toBeCalledWith(2);
+  });
+
+  test('debounced effect works after trigger', async () => {
+    const watcher = jest.fn();
+
+    const trigger = createEffect<number, void>().use(() => undefined);
+    const debounced = debounce({ source: trigger, timeout: 40 });
+
+    debounced.watch(watcher);
+
+    trigger(0);
+    trigger(1);
+    trigger(2);
+
+    expect(watcher).not.toBeCalled();
+
+    await wait(40);
+
+    trigger(3);
+    await wait(30);
+    trigger(4);
+
+    await wait(40);
+
+    expect(watcher).toBeCalledTimes(2);
+    expect(watcher).toBeCalledWith(2);
+    expect(watcher).toBeCalledWith(4);
+  });
+
+  test('calls target', async () => {
+    const watcher = jest.fn();
+
+    const source = createEvent<number>();
+    const target = createEffect<number, void>().use(() => undefined);
+
+    debounce({ source, timeout: 40, target });
+
+    target.watch(watcher);
+
+    source(1);
+    source(2);
+    source(3);
+
+    expect(watcher).not.toBeCalled();
+
+    await wait(40);
+
+    expect(watcher).toBeCalledTimes(1);
+    expect(watcher).toBeCalledWith(3);
+  });
+
+  test('with target returns target', async () => {
+    const source = createEffect<number, void>().use(() => undefined);
+    const target = createEffect<number, void>().use(() => undefined);
+
+    const result = debounce({ source, timeout: 40, target });
+
+    expect(result).toBe(target);
+  });
+
+  test('name correctly assigned from trigger', () => {
+    const demoFx = createEffect();
+    const debouncedDemo = debounce({ source: demoFx, timeout: 20 });
+
+    expect(debouncedDemo.shortName).toMatchInlineSnapshot(
+      `"demoFxDebounceTick"`,
+    );
+  });
+});
+
+describe('store', () => {
+  test('debounce store and pass values', async () => {
+    const watcher = jest.fn();
+
+    const trigger = createEvent<number>();
+    const $store = createStore(0);
+
+    $store.on(trigger, (_, value) => value);
+
+    const debounced = debounce({ source: $store, timeout: 40 });
+
+    debounced.watch(watcher);
+
+    trigger(0);
+    trigger(1);
+    trigger(2);
+
+    expect(watcher).not.toBeCalled();
+
+    await wait(40);
+
+    expect(watcher).toBeCalledTimes(1);
+    expect(watcher).toBeCalledWith(2);
+  });
+
+  test('name correctly assigned from trigger', () => {
+    const $demo = createStore(0);
+    const debouncedDemo = debounce({ source: $demo, timeout: 20 });
+
+    expect(debouncedDemo.shortName).toMatchInlineSnapshot(
+      `"$demoDebounceTick"`,
+    );
+  });
+});
+
+test('debounce do not affect another instance', async () => {
+  const watcherFirst = jest.fn();
+  const triggerFirst = createEvent<number>();
+  const debouncedFirst = debounce({ source: triggerFirst, timeout: 20 });
+  debouncedFirst.watch(watcherFirst);
+
+  const watcherSecond = jest.fn();
+  const triggerSecond = createEvent<string>();
+  const debouncedSecond = debounce({ source: triggerSecond, timeout: 60 });
+  debouncedSecond.watch(watcherSecond);
+
+  triggerFirst(0);
+
+  expect(watcherFirst).not.toBeCalled();
+  await wait(20);
+
+  expect(watcherFirst).toBeCalledWith(0);
+  expect(watcherSecond).not.toBeCalled();
+
+  triggerSecond('foo');
+  triggerFirst(1);
+  await wait(20);
+  triggerFirst(2);
+  await wait(20);
+
+  expect(watcherFirst).toBeCalledWith(2);
+  expect(watcherSecond).not.toBeCalled();
+
+  await wait(20);
+
+  expect(watcherSecond).toBeCalledWith('foo');
+});
+
+test('name correctly assigned from params', () => {
+  const demo = createEvent();
+  const debouncedDemo = debounce({
+    source: demo,
+    timeout: 20,
+    name: 'Example',
+  });
+
+  expect(debouncedDemo.shortName).toMatchInlineSnapshot(
+    `"ExampleDebounceTick"`,
+  );
+});
+
+test('name should not be in domain', () => {
+  const domain = createDomain();
+  const event = domain.createEvent();
+  const debouncedDemo = debounce({ source: event, timeout: 20 });
+
+  expect(debouncedDemo.shortName).toMatchInlineSnapshot(`"eventDebounceTick"`);
+});
+
+test('source event, target store', async () => {
+  const watcher = jest.fn();
+
+  const source = createEvent<number>();
+  const target = createStore<number>(0);
+
+  debounce({ source, timeout: 40, target });
+
+  target.updates.watch(watcher);
+
+  source(1);
+  source(2);
+  source(3);
+
+  expect(watcher).not.toBeCalled();
+
+  await wait(40);
+
+  expect(watcher).toBeCalledTimes(1);
+  expect(watcher.mock.calls).toMatchInlineSnapshot(`
+    Array [
+      Array [
+        3,
+      ],
+    ]
+  `);
+});
+
+test('source event, target effect', async () => {
+  const watcher = jest.fn();
+
+  const source = createEvent<number>();
+  const target = createEffect<number, void>().use(() => undefined);
+
+  debounce({ source, timeout: 40, target });
+
+  target.watch(watcher);
+
+  source(0);
+  source(1);
+  source(2);
+
+  expect(watcher).not.toBeCalled();
+
+  await wait(40);
+
+  expect(watcher).toBeCalledTimes(1);
+  expect(watcher.mock.calls).toMatchInlineSnapshot(`
+    Array [
+      Array [
+        2,
+      ],
+    ]
+  `);
+});
+
+test('source store, target effect', async () => {
+  const watcher = jest.fn();
+
+  const change = createEvent();
+  const source = createStore<number>(0).on(change, (state) => state + 1);
+  const target = createEffect<number, void>().use(() => undefined);
+
+  debounce({ source, timeout: 40, target });
+
+  target.watch(watcher);
+
+  change();
+  change();
+  change();
+
+  expect(watcher).not.toBeCalled();
+
+  await wait(40);
+
+  expect(watcher).toBeCalledTimes(1);
+  expect(watcher.mock.calls).toMatchInlineSnapshot(`
+    Array [
+      Array [
+        3,
+      ],
+    ]
+  `);
+});

--- a/debounce/debounce.test.ts
+++ b/debounce/debounce.test.ts
@@ -1,11 +1,10 @@
 import 'regenerator-runtime/runtime';
 import { createStore, createEvent, createEffect, createDomain } from 'effector';
+import { wait } from '../test-library';
 import { debounce } from '.';
 
-const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-
-describe('event', () => {
-  test('debounce event', async () => {
+describe('triple trigger one wait', () => {
+  test('event', async () => {
     const watcher = jest.fn();
 
     const trigger = createEvent();
@@ -16,290 +15,469 @@ describe('event', () => {
     trigger();
     trigger();
     trigger();
-
     expect(watcher).not.toBeCalled();
 
     await wait(40);
-
     expect(watcher).toBeCalledTimes(1);
   });
 
-  test('debounce event with wait', async () => {
-    const watcher = jest.fn();
-
-    const trigger = createEvent();
-    const debounced = debounce({ source: trigger, timeout: 40 });
-
-    debounced.watch(watcher);
-
-    trigger();
-
-    await wait(30);
-    trigger();
-
-    await wait(30);
-    trigger();
-
-    expect(watcher).not.toBeCalled();
-
-    await wait(40);
-
-    expect(watcher).toBeCalledTimes(1);
-  });
-
-  test('debounced event triggered with last value', async () => {
-    const watcher = jest.fn();
-
-    const trigger = createEvent<number>();
-    const debounced = debounce({ source: trigger, timeout: 40 });
-
-    debounced.watch(watcher);
-
-    trigger(0);
-    trigger(1);
-    trigger(2);
-
-    expect(watcher).not.toBeCalled();
-
-    await wait(40);
-
-    expect(watcher).toBeCalledTimes(1);
-    expect(watcher).toBeCalledWith(2);
-  });
-
-  test('debounced event works after trigger', async () => {
-    const watcher = jest.fn();
-
-    const trigger = createEvent<number>();
-    const debounced = debounce({ source: trigger, timeout: 40 });
-
-    debounced.watch(watcher);
-
-    trigger(0);
-    trigger(1);
-    trigger(2);
-
-    expect(watcher).not.toBeCalled();
-
-    await wait(40);
-
-    trigger(3);
-    await wait(30);
-    trigger(4);
-
-    await wait(40);
-
-    expect(watcher).toBeCalledTimes(2);
-    expect(watcher).toBeCalledWith(2);
-    expect(watcher).toBeCalledWith(4);
-  });
-
-  test('calls target', async () => {
-    const watcher = jest.fn();
-
-    const source = createEvent<number>();
-    const target = createEvent<number>();
-
-    debounce({ source, timeout: 40, target });
-
-    target.watch(watcher);
-
-    source(1);
-    source(2);
-    source(3);
-
-    expect(watcher).not.toBeCalled();
-
-    await wait(40);
-
-    expect(watcher).toBeCalledTimes(1);
-    expect(watcher).toBeCalledWith(3);
-  });
-
-  test('with target returns target', async () => {
-    const source = createEvent();
-    const target = createEvent();
-
-    const result = debounce({ source, timeout: 40, target });
-
-    expect(result).toBe(target);
-  });
-
-  test('name correctly assigned from trigger', () => {
-    const demo = createEvent();
-    const debouncedDemo = debounce({ source: demo, timeout: 20 });
-
-    expect(debouncedDemo.shortName).toMatchInlineSnapshot(`"demoDebounceTick"`);
-  });
-});
-
-describe('effect', () => {
-  test('debounce effect', async () => {
+  test('effect', async () => {
     const watcher = jest.fn();
 
     const trigger = createEffect<void, void>().use(() => undefined);
-    const debounced = debounce({ source: trigger, timeout: 40 });
 
+    const debounced = debounce({ source: trigger, timeout: 40 });
     debounced.watch(watcher);
 
     trigger();
     trigger();
     trigger();
-
     expect(watcher).not.toBeCalled();
 
     await wait(40);
-
     expect(watcher).toBeCalledTimes(1);
   });
 
-  test('debounce effect with wait', async () => {
-    const watcher = jest.fn();
-
-    const trigger = createEffect<void, void>().use(() => undefined);
-    const debounced = debounce({ source: trigger, timeout: 40 });
-
-    debounced.watch(watcher);
-
-    trigger();
-
-    await wait(30);
-    trigger();
-
-    await wait(30);
-    trigger();
-
-    expect(watcher).not.toBeCalled();
-
-    await wait(40);
-
-    expect(watcher).toBeCalledTimes(1);
-  });
-
-  test('debounced effect triggered with last value', async () => {
-    const watcher = jest.fn();
-
-    const trigger = createEffect<number, void>().use(() => undefined);
-    const debounced = debounce({ source: trigger, timeout: 40 });
-
-    debounced.watch(watcher);
-
-    trigger(0);
-    trigger(1);
-    trigger(2);
-
-    expect(watcher).not.toBeCalled();
-
-    await wait(40);
-
-    expect(watcher).toBeCalledTimes(1);
-    expect(watcher).toBeCalledWith(2);
-  });
-
-  test('debounced effect works after trigger', async () => {
-    const watcher = jest.fn();
-
-    const trigger = createEffect<number, void>().use(() => undefined);
-    const debounced = debounce({ source: trigger, timeout: 40 });
-
-    debounced.watch(watcher);
-
-    trigger(0);
-    trigger(1);
-    trigger(2);
-
-    expect(watcher).not.toBeCalled();
-
-    await wait(40);
-
-    trigger(3);
-    await wait(30);
-    trigger(4);
-
-    await wait(40);
-
-    expect(watcher).toBeCalledTimes(2);
-    expect(watcher).toBeCalledWith(2);
-    expect(watcher).toBeCalledWith(4);
-  });
-
-  test('calls target', async () => {
-    const watcher = jest.fn();
-
-    const source = createEvent<number>();
-    const target = createEffect<number, void>().use(() => undefined);
-
-    debounce({ source, timeout: 40, target });
-
-    target.watch(watcher);
-
-    source(1);
-    source(2);
-    source(3);
-
-    expect(watcher).not.toBeCalled();
-
-    await wait(40);
-
-    expect(watcher).toBeCalledTimes(1);
-    expect(watcher).toBeCalledWith(3);
-  });
-
-  test('with target returns target', async () => {
-    const source = createEffect<number, void>().use(() => undefined);
-    const target = createEffect<number, void>().use(() => undefined);
-
-    const result = debounce({ source, timeout: 40, target });
-
-    expect(result).toBe(target);
-  });
-
-  test('name correctly assigned from trigger', () => {
-    const demoFx = createEffect();
-    const debouncedDemo = debounce({ source: demoFx, timeout: 20 });
-
-    expect(debouncedDemo.shortName).toMatchInlineSnapshot(
-      `"demoFxDebounceTick"`,
-    );
-  });
-});
-
-describe('store', () => {
-  test('debounce store and pass values', async () => {
+  test('store', async () => {
     const watcher = jest.fn();
 
     const trigger = createEvent<number>();
-    const $store = createStore(0);
-
-    $store.on(trigger, (_, value) => value);
+    const $store = createStore(0).on(trigger, (_, value) => value);
 
     const debounced = debounce({ source: $store, timeout: 40 });
-
     debounced.watch(watcher);
 
     trigger(0);
     trigger(1);
     trigger(2);
-
     expect(watcher).not.toBeCalled();
 
     await wait(40);
+    expect(watcher).toBeCalledTimes(1);
+    expect(watcher).toBeCalledWith(2);
+  });
+});
 
+describe('too small wait after each trigger', () => {
+  test('event', async () => {
+    const watcher = jest.fn();
+    const trigger = createEvent();
+    const debounced = debounce({ source: trigger, timeout: 40 });
+    debounced.watch(watcher);
+
+    trigger();
+    await wait(30);
+    trigger();
+    await wait(30);
+    trigger();
+    expect(watcher).not.toBeCalled();
+
+    await wait(40);
+    expect(watcher).toBeCalledTimes(1);
+  });
+
+  test('effect', async () => {
+    const watcher = jest.fn();
+    const trigger = createEffect<void, void>().use(() => undefined);
+    const debounced = debounce({ source: trigger, timeout: 40 });
+    debounced.watch(watcher);
+
+    trigger();
+    await wait(30);
+    trigger();
+    await wait(30);
+    trigger();
+    expect(watcher).not.toBeCalled();
+
+    await wait(40);
+    expect(watcher).toBeCalledTimes(1);
+  });
+
+  test('effect', async () => {
+    const watcher = jest.fn();
+    const trigger = createEvent();
+    const source = createStore(0).on(trigger, (state) => state + 1);
+    const debounced = debounce({ source, timeout: 40 });
+    debounced.watch(watcher);
+
+    trigger();
+    await wait(30);
+    trigger();
+    await wait(30);
+    trigger();
+    expect(watcher).not.toBeCalled();
+
+    await wait(40);
+    expect(watcher).toBeCalledTimes(1);
+  });
+});
+
+describe('debounced triggered with latest value', () => {
+  test('event', async () => {
+    const watcher = jest.fn();
+    const trigger = createEvent<number>();
+    const debounced = debounce({ source: trigger, timeout: 40 });
+    debounced.watch(watcher);
+
+    trigger(0);
+    trigger(1);
+    trigger(2);
+    expect(watcher).not.toBeCalled();
+
+    await wait(40);
     expect(watcher).toBeCalledTimes(1);
     expect(watcher).toBeCalledWith(2);
   });
 
-  test('name correctly assigned from trigger', () => {
-    const $demo = createStore(0);
-    const debouncedDemo = debounce({ source: $demo, timeout: 20 });
+  test('effect', async () => {
+    const watcher = jest.fn();
+    const trigger = createEffect<number, void>().use(() => undefined);
+    const debounced = debounce({ source: trigger, timeout: 40 });
+    debounced.watch(watcher);
 
-    expect(debouncedDemo.shortName).toMatchInlineSnapshot(
-      `"$demoDebounceTick"`,
-    );
+    trigger(0);
+    trigger(1);
+    trigger(2);
+    expect(watcher).not.toBeCalled();
+
+    await wait(40);
+    expect(watcher).toBeCalledTimes(1);
+    expect(watcher).toBeCalledWith(2);
+  });
+
+  test('store', async () => {
+    const watcher = jest.fn();
+    const trigger = createEvent();
+    const source = createStore(0).on(trigger, (state) => state + 1);
+    const debounced = debounce({ source, timeout: 40 });
+    debounced.watch(watcher);
+
+    trigger();
+    trigger();
+    trigger();
+    expect(watcher).not.toBeCalled();
+
+    await wait(40);
+    expect(watcher).toBeCalledTimes(1);
+    expect(watcher).toBeCalledWith(3);
   });
 });
 
-test('debounce do not affect another instance', async () => {
+describe('debounced can be triggered after first', () => {
+  test('event', async () => {
+    const watcher = jest.fn();
+    const trigger = createEvent<number>();
+    const debounced = debounce({ source: trigger, timeout: 40 });
+    debounced.watch(watcher);
+
+    trigger(0);
+    trigger(1);
+    trigger(2);
+    expect(watcher).not.toBeCalled();
+
+    await wait(40);
+    expect(watcher).toBeCalledTimes(1);
+    expect(watcher).toBeCalledWith(2);
+
+    trigger(3);
+    await wait(30);
+    trigger(4);
+    await wait(40);
+
+    expect(watcher).toBeCalledTimes(2);
+    expect(watcher).toBeCalledWith(2);
+    expect(watcher).toBeCalledWith(4);
+  });
+
+  test('effect', async () => {
+    const watcher = jest.fn();
+    const trigger = createEffect<number, void>().use(() => undefined);
+    const debounced = debounce({ source: trigger, timeout: 40 });
+    debounced.watch(watcher);
+
+    trigger(0);
+    trigger(1);
+    trigger(2);
+    expect(watcher).not.toBeCalled();
+
+    await wait(40);
+    expect(watcher).toBeCalledTimes(1);
+    expect(watcher).toBeCalledWith(2);
+
+    trigger(3);
+    await wait(30);
+    trigger(4);
+    await wait(40);
+
+    expect(watcher).toBeCalledTimes(2);
+    expect(watcher).toBeCalledWith(2);
+    expect(watcher).toBeCalledWith(4);
+  });
+
+  test('store', async () => {
+    const watcher = jest.fn();
+    const trigger = createEvent();
+    const source = createStore(0).on(trigger, (state) => state + 1);
+    const debounced = debounce({ source, timeout: 40 });
+    debounced.watch(watcher);
+
+    trigger();
+    trigger();
+    trigger();
+    expect(watcher).not.toBeCalled();
+
+    await wait(40);
+    expect(watcher).toBeCalledTimes(1);
+    expect(watcher).toBeCalledWith(3);
+
+    trigger();
+    await wait(30);
+    trigger();
+    await wait(40);
+
+    expect(watcher).toBeCalledTimes(2);
+    expect(watcher).toBeCalledWith(3);
+    expect(watcher).toBeCalledWith(5);
+  });
+});
+
+describe('target triggered on debounce', () => {
+  test('event target', async () => {
+    const watcher = jest.fn();
+    const source = createEvent<number>();
+    const target = createEvent<number>();
+    debounce({ source, timeout: 40, target });
+    target.watch(watcher);
+
+    source(1);
+    source(2);
+    source(3);
+    expect(watcher).not.toBeCalled();
+
+    await wait(40);
+    expect(watcher).toBeCalledTimes(1);
+    expect(watcher).toBeCalledWith(3);
+  });
+
+  test('effect target', async () => {
+    const watcher = jest.fn();
+    const source = createEvent<number>();
+    const target = createEffect<number, void>().use(() => undefined);
+    debounce({ source, timeout: 40, target });
+    target.watch(watcher);
+
+    source(1);
+    source(2);
+    source(3);
+    expect(watcher).not.toBeCalled();
+
+    await wait(40);
+    expect(watcher).toBeCalledTimes(1);
+    expect(watcher).toBeCalledWith(3);
+  });
+
+  test('store target', async () => {
+    const watcher = jest.fn();
+    const source = createEvent<number>();
+    const target = createStore(0);
+    debounce({ source, timeout: 40, target });
+    target.updates.watch(watcher);
+
+    source(1);
+    source(2);
+    source(3);
+    expect(watcher).not.toBeCalled();
+
+    await wait(40);
+    expect(watcher).toBeCalledTimes(1);
+    expect(watcher).toBeCalledWith(3);
+  });
+});
+
+describe('target argument returns the same unit', () => {
+  test('event target', () => {
+    const source = createEvent();
+    const target = createEvent();
+    const result = debounce({ source, target, timeout: 40 });
+
+    expect(result).toBe(target);
+  });
+
+  test('effect target', () => {
+    const source = createEvent<number>();
+    const target = createEffect<number, void>();
+    const result = debounce({ source, target, timeout: 40 });
+
+    expect(result).toBe(target);
+  });
+
+  test('store target', () => {
+    const source = createEvent<number>();
+    const target = createStore(0);
+    const result = debounce({ source, target, timeout: 40 });
+
+    expect(result).toBe(target);
+  });
+});
+
+describe('source and target type combinations', () => {
+  test.todo('source event, target event');
+
+  test('source event, target store', async () => {
+    const watcher = jest.fn();
+    const source = createEvent<number>();
+    const target = createStore<number>(0);
+    debounce({ source, timeout: 40, target });
+    target.updates.watch(watcher);
+
+    source(1);
+    source(2);
+    source(3);
+    expect(watcher).not.toBeCalled();
+
+    await wait(40);
+    expect(watcher).toBeCalledTimes(1);
+    expect(watcher.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          3,
+        ],
+      ]
+    `);
+  });
+
+  test('source event, target effect', async () => {
+    const watcher = jest.fn();
+    const source = createEvent<number>();
+    const target = createEffect<number, void>().use(() => undefined);
+    debounce({ source, timeout: 40, target });
+    target.watch(watcher);
+
+    source(0);
+    source(1);
+    source(2);
+    expect(watcher).not.toBeCalled();
+
+    await wait(40);
+    expect(watcher).toBeCalledTimes(1);
+    expect(watcher.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          2,
+        ],
+      ]
+    `);
+  });
+
+  test('source store, target effect', async () => {
+    const watcher = jest.fn();
+    const change = createEvent();
+    const source = createStore<number>(0).on(change, (state) => state + 1);
+    const target = createEffect<number, void>().use(() => undefined);
+    debounce({ source, timeout: 40, target });
+    target.watch(watcher);
+
+    change();
+    change();
+    change();
+    expect(watcher).not.toBeCalled();
+
+    await wait(40);
+    expect(watcher).toBeCalledTimes(1);
+    expect(watcher.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          3,
+        ],
+      ]
+    `);
+  });
+
+  test.todo('source store, target event');
+  test.todo('source store, target store');
+
+  test.todo('source effect, target event');
+  test.todo('source effect, target store');
+  test.todo('source effect, target effect');
+});
+
+describe('name assigned from source', () => {
+  test('event', () => {
+    const source = createEvent();
+    const debounced = debounce({ source, timeout: 40 });
+
+    expect(debounced.shortName).toMatchInlineSnapshot(`"sourceDebounceTick"`);
+  });
+
+  test('store', () => {
+    const $source = createStore(0);
+    const debounced = debounce({ source: $source, timeout: 40 });
+
+    expect(debounced.shortName).toMatchInlineSnapshot(`"$sourceDebounceTick"`);
+  });
+
+  test('effect', () => {
+    const sourceFx = createEffect();
+    const debounced = debounce({ source: sourceFx, timeout: 40 });
+
+    expect(debounced.shortName).toMatchInlineSnapshot(`"sourceFxDebounceTick"`);
+  });
+});
+
+describe('name assigned from params', () => {
+  test('event', () => {
+    const source = createEvent();
+    const debounced = debounce({ source, name: 'hello', timeout: 40 });
+
+    expect(debounced.shortName).toMatchInlineSnapshot(`"helloDebounceTick"`);
+  });
+
+  test('store', () => {
+    const $source = createStore(0);
+    const debounced = debounce({ source: $source, name: 'hello', timeout: 40 });
+
+    expect(debounced.shortName).toMatchInlineSnapshot(`"helloDebounceTick"`);
+  });
+
+  test('effect', () => {
+    const sourceFx = createEffect();
+    const debounced = debounce({
+      source: sourceFx,
+      name: 'hello',
+      timeout: 40,
+    });
+
+    expect(debounced.shortName).toMatchInlineSnapshot(`"helloDebounceTick"`);
+  });
+});
+
+describe('name of debounced should not inherit domain', () => {
+  test('event', () => {
+    const domain = createDomain();
+    const source = domain.createEvent();
+    const debounced = debounce({ source, timeout: 40 });
+
+    expect(debounced.shortName).toMatchInlineSnapshot(`"sourceDebounceTick"`);
+  });
+
+  test('store', () => {
+    const domain = createDomain();
+    const $source = domain.createStore(0);
+    const debounced = debounce({ source: $source, timeout: 40 });
+
+    expect(debounced.shortName).toMatchInlineSnapshot(`"$sourceDebounceTick"`);
+  });
+
+  test('effect', () => {
+    const domain = createDomain();
+    const sourceFx = domain.createEffect();
+    const debounced = debounce({ source: sourceFx, timeout: 40 });
+
+    expect(debounced.shortName).toMatchInlineSnapshot(`"sourceFxDebounceTick"`);
+  });
+});
+
+test('debounce do not affect another instance of debounce', async () => {
   const watcherFirst = jest.fn();
   const triggerFirst = createEvent<number>();
   const debouncedFirst = debounce({ source: triggerFirst, timeout: 20 });
@@ -311,10 +489,9 @@ test('debounce do not affect another instance', async () => {
   debouncedSecond.watch(watcherSecond);
 
   triggerFirst(0);
-
   expect(watcherFirst).not.toBeCalled();
-  await wait(20);
 
+  await wait(20);
   expect(watcherFirst).toBeCalledWith(0);
   expect(watcherSecond).not.toBeCalled();
 
@@ -322,118 +499,11 @@ test('debounce do not affect another instance', async () => {
   triggerFirst(1);
   await wait(20);
   triggerFirst(2);
-  await wait(20);
 
+  await wait(20);
   expect(watcherFirst).toBeCalledWith(2);
   expect(watcherSecond).not.toBeCalled();
 
   await wait(20);
-
   expect(watcherSecond).toBeCalledWith('foo');
-});
-
-test('name correctly assigned from params', () => {
-  const demo = createEvent();
-  const debouncedDemo = debounce({
-    source: demo,
-    timeout: 20,
-    name: 'Example',
-  });
-
-  expect(debouncedDemo.shortName).toMatchInlineSnapshot(
-    `"ExampleDebounceTick"`,
-  );
-});
-
-test('name should not be in domain', () => {
-  const domain = createDomain();
-  const event = domain.createEvent();
-  const debouncedDemo = debounce({ source: event, timeout: 20 });
-
-  expect(debouncedDemo.shortName).toMatchInlineSnapshot(`"eventDebounceTick"`);
-});
-
-test('source event, target store', async () => {
-  const watcher = jest.fn();
-
-  const source = createEvent<number>();
-  const target = createStore<number>(0);
-
-  debounce({ source, timeout: 40, target });
-
-  target.updates.watch(watcher);
-
-  source(1);
-  source(2);
-  source(3);
-
-  expect(watcher).not.toBeCalled();
-
-  await wait(40);
-
-  expect(watcher).toBeCalledTimes(1);
-  expect(watcher.mock.calls).toMatchInlineSnapshot(`
-    Array [
-      Array [
-        3,
-      ],
-    ]
-  `);
-});
-
-test('source event, target effect', async () => {
-  const watcher = jest.fn();
-
-  const source = createEvent<number>();
-  const target = createEffect<number, void>().use(() => undefined);
-
-  debounce({ source, timeout: 40, target });
-
-  target.watch(watcher);
-
-  source(0);
-  source(1);
-  source(2);
-
-  expect(watcher).not.toBeCalled();
-
-  await wait(40);
-
-  expect(watcher).toBeCalledTimes(1);
-  expect(watcher.mock.calls).toMatchInlineSnapshot(`
-    Array [
-      Array [
-        2,
-      ],
-    ]
-  `);
-});
-
-test('source store, target effect', async () => {
-  const watcher = jest.fn();
-
-  const change = createEvent();
-  const source = createStore<number>(0).on(change, (state) => state + 1);
-  const target = createEffect<number, void>().use(() => undefined);
-
-  debounce({ source, timeout: 40, target });
-
-  target.watch(watcher);
-
-  change();
-  change();
-  change();
-
-  expect(watcher).not.toBeCalled();
-
-  await wait(40);
-
-  expect(watcher).toBeCalledTimes(1);
-  expect(watcher.mock.calls).toMatchInlineSnapshot(`
-    Array [
-      Array [
-        3,
-      ],
-    ]
-  `);
 });

--- a/debounce/index.d.ts
+++ b/debounce/index.d.ts
@@ -1,3 +1,13 @@
-import { createDebounce } from 'effector-debounce';
+import { Unit, Event } from 'effector';
 
-export const debounce = createDebounce;
+export function debounce<T>(_: {
+  source: Unit<T>;
+  timeout: number;
+  name?: string;
+}): Event<T>;
+export function debounce<T, R extends Unit<T>>(_: {
+  source: Unit<T>;
+  timeout: number;
+  target: R;
+  name?: string;
+}): R;

--- a/debounce/index.js
+++ b/debounce/index.js
@@ -1,5 +1,61 @@
-const { createDebounce } = require('effector-debounce');
+const { is, createEffect, forward, createEvent } = require('effector');
+const { readConfig } = require('../library');
 
-module.exports = {
-  debounce: createDebounce,
-};
+function debounce(argument) {
+  const { source, timeout, target, sid, loc, name } = readConfig(argument, [
+    'source',
+    'timeout',
+    'target',
+
+    'loc',
+    'name',
+    'sid',
+  ]);
+
+  if (!is.unit(source)) throw new Error('source must be unit from effector');
+  if (typeof timeout !== 'number' || timeout < 0)
+    throw new Error('timeout must be positive number or zero');
+
+  const actualName = name || source.shortName || 'unknown';
+
+  // eslint-disable-next-line unicorn/consistent-function-scoping
+  let rejectPromise = () => undefined;
+  let timeoutId;
+
+  const tick =
+    target ||
+    createEvent({
+      name: `${actualName}DebounceTick`,
+      loc,
+    });
+
+  const timerFx = createEffect({
+    name: `${actualName}ThrottleTimer`,
+    sid,
+    loc,
+    handler: (parameter) =>
+      new Promise((resolve, reject) => {
+        rejectPromise = reject;
+        timeoutId = setTimeout(resolve, timeout, parameter);
+      }),
+  });
+
+  timerFx.watch(() => {
+    clearTimeout(timeoutId);
+    rejectPromise();
+  });
+
+  forward({
+    from: source,
+    to: timerFx,
+  });
+
+  forward({
+    from: timerFx.done.map(({ result }) => result),
+    to: tick,
+  });
+
+  return tick;
+}
+
+module.exports = { debounce };

--- a/debounce/index.js
+++ b/debounce/index.js
@@ -18,8 +18,7 @@ function debounce(argument) {
 
   const actualName = name || source.shortName || 'unknown';
 
-  // eslint-disable-next-line unicorn/consistent-function-scoping
-  let rejectPromise = () => undefined;
+  let rejectPromise;
   let timeoutId;
 
   const tick =
@@ -33,16 +32,14 @@ function debounce(argument) {
     name: `${actualName}ThrottleTimer`,
     sid,
     loc,
-    handler: (parameter) =>
-      new Promise((resolve, reject) => {
+    handler: (parameter) => {
+      clearTimeout(timeoutId);
+      if (rejectPromise) rejectPromise();
+      return new Promise((resolve, reject) => {
         rejectPromise = reject;
         timeoutId = setTimeout(resolve, timeout, parameter);
-      }),
-  });
-
-  timerFx.watch(() => {
-    clearTimeout(timeoutId);
-    rejectPromise();
+      });
+    },
   });
 
   forward({

--- a/debounce/readme.md
+++ b/debounce/readme.md
@@ -13,7 +13,10 @@ import { debounce } from 'patronum/debounce';
 const DEBOUNCE_TIMEOUT_IN_MS = 200;
 
 const someHappened = createEvent<number>();
-const debounced = debounce(someHappened, DEBOUNCE_TIMEOUT_IN_MS);
+const debounced = debounce({
+  source: someHappened,
+  timeout: DEBOUNCE_TIMEOUT_IN_MS,
+});
 
 debounced.watch((payload) => {
   console.info('someHappened now', payload);

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@babel/preset-typescript": "^7.10.1",
     "@commitlint/cli": "8.2.0",
     "@commitlint/config-conventional": "8.2.0",
-    "@types/jest": "^25.2.1",
+    "@types/jest": "^26.0.0",
     "@typescript-eslint/eslint-plugin": "^2.12.0",
     "@typescript-eslint/parser": "^2.12.0",
     "camel-case": "^4.1.1",

--- a/test-d/debounce.ts
+++ b/test-d/debounce.ts
@@ -1,0 +1,121 @@
+import { expectType, expectError } from 'tsd';
+import {
+  Store,
+  Event,
+  Effect,
+  createStore,
+  createEvent,
+  createEffect,
+} from 'effector';
+import { debounce } from '../debounce';
+
+// Returns the same type as source
+{
+  const $source = createStore(0);
+  expectType<Event<number>>(debounce({ source: $source, timeout: 10 }));
+
+  const source = createEvent<string>();
+  expectType<Event<string>>(debounce({ source, timeout: 10 }));
+
+  const sourceUnion = createEvent<'demo' | 'another'>();
+  expectType<Event<'demo' | 'another'>>(
+    debounce({ source: sourceUnion, timeout: 10 }),
+  );
+
+  const sourceFx = createEffect<boolean, void>();
+  expectType<Event<boolean>>(debounce({ source: sourceFx, timeout: 10 }));
+}
+
+// Source should be unit
+{
+  expectError(debounce({ timeout: 10 }));
+  expectError(debounce({ timeout: 10, source: null }));
+  expectError(debounce({ timeout: 10, source: undefined }));
+  expectError(debounce({ timeout: 10, source: true }));
+  expectError(debounce({ timeout: 10, source: 'f' }));
+  expectError(debounce({ timeout: 10, source: Symbol() }));
+  expectError(debounce({ timeout: 10, source: () => {} }));
+  expectError(debounce({ timeout: 10, source: {} }));
+  expectError(debounce({ timeout: 10, source: [] }));
+}
+
+// Timeout should be only number
+{
+  const source = createEvent();
+  expectType<Event<void>>(debounce({ source, timeout: 10 }));
+
+  expectError(debounce({ source }));
+  expectError(debounce({ source, timeout: null }));
+  expectError(debounce({ source, timeout: undefined }));
+  expectError(debounce({ source, timeout: true }));
+  expectError(debounce({ source, timeout: 'f' }));
+  expectError(debounce({ source, timeout: Symbol() }));
+  expectError(debounce({ source, timeout: () => {} }));
+  expectError(debounce({ source, timeout: {} }));
+  expectError(debounce({ source, timeout: [] }));
+}
+
+// Source and target should be compatible
+// Returns the same type as target
+{
+  expectType<Event<number>>(
+    debounce({
+      source: createStore(0),
+      timeout: 10,
+      target: createEvent<number>(),
+    }),
+  );
+
+  expectType<Effect<string, void>>(
+    debounce({
+      source: createStore(''),
+      timeout: 10,
+      target: createEffect<string, void>(),
+    }),
+  );
+
+  expectType<Store<string>>(
+    debounce({
+      source: createEffect<string, void>(),
+      timeout: 10,
+      target: createStore(''),
+    }),
+  );
+}
+
+// Name argument is a string without target
+{
+  const source = createEvent();
+  expectType<Event<void>>(debounce({ source, timeout: 10 }));
+  expectType<Event<void>>(debounce({ source, timeout: 10, name: undefined }));
+  expectType<Event<void>>(debounce({ source, timeout: 10, name: 'demo' }));
+
+  expectError(debounce({ source, timeout: 10, name: null }));
+  expectError(debounce({ source, timeout: 10, name: true }));
+  expectError(debounce({ source, timeout: 10, name: Symbol() }));
+  expectError(debounce({ source, timeout: 10, name: 6 }));
+  expectError(debounce({ source, timeout: 10, name: () => {} }));
+  expectError(debounce({ source, timeout: 10, name: {} }));
+  expectError(debounce({ source, timeout: 10, name: [] }));
+}
+
+// Name argument is a string with target
+{
+  const source = createEvent<number>();
+  const target = createStore(0);
+  expectType<Store<number>>(debounce({ source, target, timeout: 10 }));
+  expectType<Store<number>>(
+    debounce({ source, target, timeout: 10, name: undefined }),
+  );
+  expectType<Store<number>>(
+    debounce({ source, target, timeout: 10, name: 'demo' }),
+  );
+
+  expectError(debounce({ source, target, timeout: 10, name: null }));
+  expectError(debounce({ source, target, timeout: 10, name: true }));
+  expectError(debounce({ source, target, timeout: 10, name: Symbol() }));
+  expectError(debounce({ source, target, timeout: 10, name: 6 }));
+  expectError(debounce({ source, target, timeout: 10, name: () => {} }));
+  expectError(debounce({ source, target, timeout: 10, name: {} }));
+  expectError(debounce({ source, target, timeout: 10, name: [] }));
+}

--- a/test-library.d.ts
+++ b/test-library.d.ts
@@ -1,0 +1,9 @@
+import { Unit } from 'effector';
+
+export function waitFor<T>(unit: Unit<T>): Promise<T>;
+
+type Mock = ReturnType<typeof jest.fn>;
+
+export function argumentHistory(ƒ: Mock): Array<string>;
+
+export function wait(ms: number): Promise<void>;

--- a/test-library.js
+++ b/test-library.js
@@ -52,4 +52,12 @@ function toBeCloseWithThreshold(received, expected, threshold) {
   };
 }
 
-module.exports = { argumentHistory, waitFor, time, toBeCloseWithThreshold };
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+module.exports = {
+  argumentHistory,
+  time,
+  toBeCloseWithThreshold,
+  wait,
+  waitFor,
+};

--- a/throttle/index.js
+++ b/throttle/index.js
@@ -13,7 +13,7 @@ function throttle(argument) {
   ]);
 
   if (!is.unit(source))
-    throw new TypeError('callee must be unit from effector');
+    throw new TypeError('source must be unit from effector');
   if (typeof timeout !== 'number' || timeout < 0)
     throw new Error('timeout must be positive number or zero');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1508,10 +1508,10 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@^25.2.1":
-  version "25.2.3"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-25.2.3.tgz#33d27e4c4716caae4eced355097a47ad363fdcaf"
-  integrity sha512-JXc1nK/tXHiDhV55dvfzqtmP4S3sy3T3ouV2tkViZgxY/zeUkcpQcQPGRlgF4KmWzWW5oiWYSZwtCB+2RsE4Fw==
+"@types/jest@^26.0.0":
+  version "26.0.0"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.0.tgz#a6d7573dffa9c68cbbdf38f2e0de26f159e11134"
+  integrity sha512-/yeMsH9HQ1RLORlXAwoLXe8S98xxvhNtUz3yrgrwbaxYjT+6SFPZZRksmRKRA6L5vsUtSHeN71viDOTTyYAD+g==
   dependencies:
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"


### PR DESCRIPTION
Migrate debounce and implement object arguments form with target support

```ts
const debounced = debounce({ source, timeout: 10 })

// or

debounce({ source, timeout: 10, target })
```

Closes #24 