### PR TITLE
Refactored `splitMap` to object form arguments

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -55,6 +55,7 @@
     "@typescript-eslint/no-use-before-define": "off",
     "unicorn/prefer-spread": "off",
     "prefer-rest-params": "off",
-    "no-param-reassign": "off"
+    "no-param-reassign": "off",
+    "no-underscore-dangle": "off"
   }
 }

--- a/README.md
+++ b/README.md
@@ -257,9 +257,12 @@ import { splitMap } from 'patronum/split-map';
 
 const nameReceived = createEvent<string>();
 
-const received = splitMap(nameReceived, {
-  firstName: (string) => string.split(' ')[0], // string | undefined
-  lastName: (string) => string.split(' ')[1], // string | undefined
+const received = splitMap({
+  source: nameReceived,
+  cases: {
+    firstName: (string) => string.split(' ')[0], // string | undefined
+    lastName: (string) => string.split(' ')[1], // string | undefined
+  },
 });
 
 received.firstName.watch((first) => console.info('firstname received', first));

--- a/split-map/index.d.ts
+++ b/split-map/index.d.ts
@@ -1,12 +1,12 @@
-import { Event } from 'effector';
+import { Unit, Event } from 'effector';
 
 export function splitMap<
   S,
   Cases extends Record<string, (payload: S) => any | undefined>
->(
-  source: Event<S>,
-  cases: Cases,
-): {
+>(_: {
+  source: Unit<S>;
+  cases: Cases;
+}): {
   [K in keyof Cases]: Cases[K] extends (p: S) => infer R
     ? Event<Exclude<R, undefined>>
     : never;

--- a/split-map/index.js
+++ b/split-map/index.js
@@ -1,6 +1,8 @@
 const { is } = require('effector');
+const { readConfig } = require('../library');
 
-function splitMap(source, cases) {
+function splitMap(argument) {
+  const { source, cases } = readConfig(argument, ['source', 'cases']);
   const result = {};
 
   let current = is.store(source) ? source.updates : source;

--- a/split-map/readme.md
+++ b/split-map/readme.md
@@ -16,9 +16,12 @@ import { splitMap } from 'patronum/split-map';
 
 const event = createEvent<object>();
 
-const extractors = splitMap(event, {
-  getType: (input) => input.type,
-  getDemo: (input) => input.demo,
+const extractors = splitMap({
+  source: event,
+  cases: {
+    getType: (input) => input.type,
+    getDemo: (input) => input.demo,
+  },
 });
 
 extractors.getType.watch((type) => console.log('TYPE', type));

--- a/split-map/split-map.fork.test.ts
+++ b/split-map/split-map.fork.test.ts
@@ -1,0 +1,113 @@
+import 'regenerator-runtime/runtime';
+import { createDomain } from 'effector';
+import { fork, serialize, allSettled } from 'effector/fork';
+import { splitMap } from '.';
+
+test('works in forked scope', async () => {
+  const app = createDomain();
+  const source = app.createEvent<{ first?: number; another?: boolean }>();
+  const out = splitMap({
+    source,
+    cases: {
+      first: (payload) => payload.first,
+    },
+  });
+
+  const $data = app.createStore(0);
+
+  $data
+    .on(out.first, (state, payload) => state + payload)
+    .on(out.__, (state, payload) => (payload ? -state : 0));
+
+  const scope = fork(app);
+
+  await allSettled(source, {
+    scope,
+    params: { first: 15 },
+  });
+  expect(serialize(scope)).toMatchInlineSnapshot(`
+    Object {
+      "-rzpinn": 15,
+    }
+  `);
+
+  await allSettled(source, {
+    scope,
+    params: { another: true },
+  });
+  expect(serialize(scope)).toMatchInlineSnapshot(`
+    Object {
+      "-rzpinn": -15,
+    }
+  `);
+});
+
+test('do not affect another fork', async () => {
+  const app = createDomain();
+  const source = app.createEvent<{ first?: number; another?: boolean }>();
+  const out = splitMap({
+    source,
+    cases: {
+      first: (payload) => payload.first,
+    },
+  });
+
+  const $data = app.createStore(0);
+
+  $data
+    .on(out.first, (state, payload) => state + payload)
+    .on(out.__, (state, payload) => (payload ? -state : 0));
+
+  const scopeA = fork(app);
+  const scopeB = fork(app);
+
+  await allSettled(source, {
+    scope: scopeA,
+    params: { first: 200 },
+  });
+  expect(serialize(scopeA)).toMatchInlineSnapshot(`
+    Object {
+      "u8tzua": 200,
+    }
+  `);
+
+  await allSettled(source, {
+    scope: scopeB,
+    params: { first: -5 },
+  });
+  expect(serialize(scopeB)).toMatchInlineSnapshot(`
+    Object {
+      "u8tzua": -5,
+    }
+  `);
+});
+
+test('do not affect original store value', async () => {
+  const app = createDomain();
+  const source = app.createEvent<{ first?: number; another?: boolean }>();
+  const out = splitMap({
+    source,
+    cases: {
+      first: (payload) => payload.first,
+    },
+  });
+
+  const $data = app.createStore(0);
+
+  $data
+    .on(out.first, (state, payload) => state + payload)
+    .on(out.__, (state, payload) => (payload ? -state : 0));
+
+  const scope = fork(app);
+
+  await allSettled(source, {
+    scope,
+    params: { first: 15 },
+  });
+  expect(serialize(scope)).toMatchInlineSnapshot(`
+    Object {
+      "hxb2ra": 15,
+    }
+  `);
+  expect($data.getState()).toBe($data.defaultState);
+});

--- a/test-d/split-map.ts
+++ b/test-d/split-map.ts
@@ -1,0 +1,60 @@
+// import { expectType, expectError } from 'tsd';
+// import { Store, Event, createStore, createEvent, createEffect } from 'effector';
+// import { splitMap } from '../split-map';
+
+// // Allow any unit as source
+// {
+//   const event = createEvent<number>();
+//   const $store = createStore(0);
+//   const effect = createEffect<string, void>();
+
+//   expectType<{ demo: Event<boolean>; __: Event<number> }>(
+//     splitMap({
+//       source: event,
+//       cases: {
+//         demo: () => true,
+//       },
+//     }),
+//   );
+//   expectType<{ demo: Event<boolean>; __: Event<number> }>(
+//     splitMap({
+//       source: $store,
+//       cases: {
+//         demo: () => true,
+//       },
+//     }),
+//   );
+//   expectType<{ demo: Event<boolean>; __: Event<string> }>(
+//     splitMap({
+//       source: effect,
+//       cases: {
+//         demo: () => true,
+//       },
+//     }),
+//   );
+// }
+
+// // Has default case
+// {
+//   expectType<{ __: Event<number> }>(
+//     splitMap({ source: createEvent<number>(), cases: {} }),
+//   );
+//   expectType<{ __: Event<{ demo: number }> }>(
+//     splitMap({ source: createEvent<{ demo: number }>(), cases: {} }),
+//   );
+// }
+
+// // Omit undefined from object type
+// {
+//   type Payload = { key?: string };
+//   const source = createEvent<Payload>();
+
+//   expectType<{ example: Event<string>; __: Event<Payload> }>(
+//     splitMap({
+//       source,
+//       cases: {
+//         example: (object) => object.key,
+//       },
+//     }),
+//   );
+// }


### PR DESCRIPTION
closes #35

```ts
// before
const received = splitMap(nameReceived, {
  firstName: (string) => string.split(' ')[0], // string | undefined
  lastName: (string) => string.split(' ')[1], // string | undefined
});

// now
const received = splitMap({
  source: nameReceived,
  cases: {
    firstName: (string) => string.split(' ')[0], // string | undefined
    lastName: (string) => string.split(' ')[1], // string | undefined
});
```