### PR TITLE
Refactored `some` method (object form arguments)

### DIFF
--- a/some/index.d.ts
+++ b/some/index.d.ts
@@ -1,13 +1,16 @@
 import { Store } from 'effector';
 
-export function some<T>(
-  predicate: (value: T) => boolean,
-  stores: Array<Store<T>>,
-): Store<boolean>;
+export function some<T>(_: {
+  predicate: (value: T) => boolean;
+  stores: Array<Store<T>>;
+}): Store<boolean>;
 
-export function some<T extends string>(
-  value: T,
-  stores: Array<Store<T>>,
-): Store<boolean>;
+export function some<T extends string>(_: {
+  predicate: T;
+  stores: Array<Store<T>>;
+}): Store<boolean>;
 
-export function some<T>(value: T, stores: Array<Store<T>>): Store<boolean>;
+export function some<T>(_: {
+  predicate: T;
+  stores: Array<Store<T>>;
+}): Store<boolean>;

--- a/some/index.js
+++ b/some/index.js
@@ -1,11 +1,14 @@
 const { combine } = require('effector');
+const { readConfig } = require('../library');
 
-function some(predicate, list) {
+function some(argument) {
+  const { predicate, stores } = readConfig(argument, ['predicate', 'stores']);
+
   const checker = isFunction(predicate)
     ? predicate
     : (value) => value === predicate;
 
-  return combine(list, (values) => values.some(checker));
+  return combine(stores, (values) => values.some(checker));
 }
 
 module.exports = { some };

--- a/some/readme.md
+++ b/some/readme.md
@@ -4,12 +4,13 @@
 import { some } from 'patronum/some';
 ```
 
-## `some(predicate, stores)`
+## `some({ predicate: Function, stores })`
 
 ```ts
-$result = some(predicate, stores);
+$result = some({ predicate: (value) => true, stores });
 ```
 
+- read it as: has some predicate at at least one store
 - `$result` will be `true` if each at least `predicate` on each store value from `values` returns `true`, otherwise it will be `false`
 
 ### Arguments
@@ -27,24 +28,27 @@ $result = some(predicate, stores);
 const $width = createStore(440);
 const $height = createStore(820);
 
-const $tooBig = some((size) => size > 800, [$width, $height]);
+const $tooBig = some({
+  predicate: (size) => size > 800,
+  stores: [$width, $height],
+});
 
 console.assert(true === $tooBig.getState());
 ```
 
-## `some(value, stores)`
+## `some({ predicate: value, stores })`
 
 ```ts
-$result = some(value, stores);
+$result = some({ predicate: value, stores });
 ```
 
-- `$result` will be `true` if at least one value in `stores` equals `values`, otherwise it will be `false`
+- `$result` will be `true` if at least one value in `stores` equals `value`, otherwise it will be `false`
 
 ### Arguments
 
-1. `value` _(`T`)_ — Data to compare stores values with
+1. `predicate` _(`T`)_ — Data to compare stores values with
 1. `stores` _(`Array<Store<T>>`)_ — List of stores to compare with `value`
-1. type of `value` and `stores` should should be the same
+1. type of `predicate` and `stores` should should be the same
 
 ### Return
 
@@ -56,7 +60,10 @@ $result = some(value, stores);
 const $isPasswordCorrect = createStore(true);
 const $isEmailCorrect = createStore(true);
 
-const $isFormFailed = some(false, [$isPasswordCorrect, $isEmailCorrect]);
+const $isFormFailed = some({
+  predicate: false,
+  stores: [$isPasswordCorrect, $isEmailCorrect],
+});
 
 console.assert(false === $isFormFailed.getState());
 ```

--- a/some/some.fork.test.ts
+++ b/some/some.fork.test.ts
@@ -1,0 +1,123 @@
+import 'regenerator-runtime/runtime';
+import { createDomain } from 'effector';
+import { fork, serialize, allSettled } from 'effector/fork';
+import { some } from '.';
+
+test('throttle works in forked scope', async () => {
+  const app = createDomain();
+  const change = app.createEvent();
+  const $first = app.createStore(0);
+  const $second = app.createStore(0).on(change, () => 1);
+  const $third = app.createStore(0);
+
+  const $result = some({ predicate: 1, stores: [$first, $second, $third] });
+
+  const scope = fork(app);
+
+  await allSettled(change, {
+    scope,
+    params: undefined,
+  });
+
+  expect(serialize(scope)).toMatchInlineSnapshot(`
+    Object {
+      "-b0ikr1": 1,
+      "-lkk1fg": true,
+      "-vkjewi": 0,
+      "-wlfbo8": 0,
+    }
+  `);
+});
+
+test('throttle do not affect another forks', async () => {
+  const app = createDomain();
+  const change = app.createEvent<number>();
+  const $first = app.createStore(0);
+  const $second = app
+    .createStore(0)
+    .on(change, (state, payload) => state + payload);
+  const $third = app.createStore(0);
+
+  const $result = some({
+    predicate: (x) => x > 0,
+    stores: [$first, $second, $third],
+  });
+
+  const scopeA = fork(app);
+  const scopeB = fork(app);
+
+  await allSettled(change, {
+    scope: scopeA,
+    params: 1,
+  });
+
+  await allSettled(change, {
+    scope: scopeB,
+    params: 100,
+  });
+
+  await allSettled(change, {
+    scope: scopeA,
+    params: 1,
+  });
+
+  await allSettled(change, {
+    scope: scopeB,
+    params: 100,
+  });
+
+  expect(serialize(scopeA)).toMatchInlineSnapshot(`
+    Object {
+      "-lkk1fg": true,
+      "35aewt": 0,
+      "jq7xe": 0,
+      "l6jq27": 2,
+    }
+  `);
+  expect(serialize(scopeB)).toMatchInlineSnapshot(`
+    Object {
+      "-lkk1fg": true,
+      "35aewt": 0,
+      "jq7xe": 0,
+      "l6jq27": 200,
+    }
+  `);
+});
+
+test('throttle do not affect original store value', async () => {
+  const app = createDomain();
+  const change = app.createEvent<number>();
+  const $first = app.createStore(0);
+  const $second = app
+    .createStore(0)
+    .on(change, (state, payload) => state + payload);
+  const $third = app.createStore(0);
+
+  const $result = some({
+    predicate: (x) => x > 0,
+    stores: [$first, $second, $third],
+  });
+
+  const scope = fork(app);
+
+  await allSettled(change, {
+    scope,
+    params: 1,
+  });
+
+  await allSettled(change, {
+    scope,
+    params: 1,
+  });
+
+  expect(serialize(scope)).toMatchInlineSnapshot(`
+    Object {
+      "-lkk1fg": true,
+      "-z6isiu": 2,
+      "f7rrbh": 0,
+      "htbyaw": 0,
+    }
+  `);
+
+  expect($result.getState()).toMatchInlineSnapshot(`false`);
+});

--- a/some/some.test.ts
+++ b/some/some.test.ts
@@ -1,6 +1,6 @@
-const { createStore, createEvent } = require('effector');
-const { argumentHistory } = require('../test-library');
-const { some } = require('./index');
+import { createStore, createEvent } from 'effector';
+import { argumentHistory } from '../test-library';
+import { some } from './index';
 
 test('boolean predicate', () => {
   const fn = jest.fn();
@@ -11,7 +11,7 @@ test('boolean predicate', () => {
   const $second = createStore(false).on(changeOne, () => true);
   const $third = createStore(false).on(changeAnother, () => true);
 
-  const $result = some(true, [$first, $second, $third]);
+  const $result = some({ predicate: true, stores: [$first, $second, $third] });
 
   $result.watch(fn);
   expect(fn).toHaveBeenCalledWith(false);
@@ -46,7 +46,7 @@ test('number predicate', () => {
   const $second = createStore(2).on(change, () => 4);
   const $third = createStore(4);
 
-  const $result = some(2, [$first, $second, $third]);
+  const $result = some({ predicate: 2, stores: [$first, $second, $third] });
 
   $result.watch(fn);
   expect(fn).toHaveBeenCalledWith(true);
@@ -68,7 +68,10 @@ test('function predicate', () => {
   const $second = createStore(0).on(change, () => 5);
   const $third = createStore(0);
 
-  const $result = some((value) => value > 0, [$first, $second, $third]);
+  const $result = some({
+    predicate: (value) => value > 0,
+    stores: [$first, $second, $third],
+  });
 
   $result.watch(fn);
   expect(fn).toHaveBeenCalledWith(false);
@@ -89,7 +92,10 @@ test('initially true', () => {
   const $second = createStore(2);
   const $third = createStore(0);
 
-  const $result = some((value) => value > 0, [$first, $second, $third]);
+  const $result = some({
+    predicate: (value) => value > 0,
+    stores: [$first, $second, $third],
+  });
 
   $result.watch(fn);
   expect(fn).toHaveBeenCalledWith(true);
@@ -102,7 +108,10 @@ test('initially false', () => {
   const $second = createStore(0);
   const $third = createStore(0);
 
-  const $result = some((value) => value > 0, [$first, $second, $third]);
+  const $result = some({
+    predicate: (value) => value > 0,
+    stores: [$first, $second, $third],
+  });
 
   $result.watch(fn);
   expect(fn).toHaveBeenCalledWith(false);

--- a/test-d/some.ts
+++ b/test-d/some.ts
@@ -8,9 +8,9 @@ import { some } from '../some';
   const $b = createStore(1);
   const $invalid = createStore('');
 
-  expectType<Store<boolean>>(some(0, [$a, $b]));
+  expectType<Store<boolean>>(some({ predicate: 0, stores: [$a, $b] }));
 
-  expectError(some(0, [$a, $invalid]));
+  expectError(some({ predicate: 0, stores: [$a, $invalid] }));
 }
 
 // Check types for string enum
@@ -22,9 +22,9 @@ import { some } from '../some';
 
   const value: Enum = 'c';
 
-  expectType<Store<boolean>>(some(value, [$a, $b]));
-  expectError(some(value, [$a, $invalid]));
-  expectError(some('demo', [$a, $b]));
+  expectType<Store<boolean>>(some({ predicate: value, stores: [$a, $b] }));
+  expectError(some({ predicate: value, stores: [$a, $invalid] }));
+  expectError(some({ predicate: 'demo', stores: [$a, $b] }));
 }
 
 // Check function predicate
@@ -34,6 +34,6 @@ import { some } from '../some';
   const $b = createStore(1);
   const $invalid = createStore('');
 
-  expectType<Store<boolean>>(some(predicate, [$a, $b]));
-  expectError(some(predicate, [$a, $invalid]));
+  expectType<Store<boolean>>(some({ predicate, stores: [$a, $b] }));
+  expectError(some({ predicate, stores: [$a, $invalid] }));
 }


### PR DESCRIPTION
```ts
// before
const $tooBig = some((size) => size > 800, [$width, $height]);

// now
const $tooBig = some({
  predicate: (size) => size > 800,
  stores: [$width, $height],
});
```

closes #21 