### PR TITLE
Add object arguments form for `every` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,10 @@ event3(5); // triggered { event1: true, event2: "demo", event3: 5 }
 const $isPasswordCorrect = createStore(true);
 const $isEmailCorrect = createStore(true);
 
-const $isFormCorrect = every(true, [$isPasswordCorrect, $isEmailCorrect]);
+const $isFormCorrect = every({
+  predicate: true,
+  stores: [$isPasswordCorrect, $isEmailCorrect],
+});
 // true
 ```
 

--- a/every/every.fork.test.ts
+++ b/every/every.fork.test.ts
@@ -1,0 +1,123 @@
+import 'regenerator-runtime/runtime';
+import { createDomain } from 'effector';
+import { fork, serialize, allSettled } from 'effector/fork';
+import { every } from '.';
+
+test('throttle works in forked scope', async () => {
+  const app = createDomain();
+  const change = app.createEvent();
+  const $first = app.createStore(0);
+  const $second = app.createStore(1).on(change, () => 0);
+  const $third = app.createStore(0);
+
+  const $result = every({ predicate: 1, stores: [$first, $second, $third] });
+
+  const scope = fork(app);
+
+  await allSettled(change, {
+    scope,
+    params: undefined,
+  });
+
+  expect(serialize(scope)).toMatchInlineSnapshot(`
+    Object {
+      "-9xrduy": 0,
+      "-q07q39": 0,
+      "ij1gv4": 0,
+      "ryha7v": false,
+    }
+  `);
+});
+
+test('throttle do not affect another forks', async () => {
+  const app = createDomain();
+  const change = app.createEvent<number>();
+  const $first = app.createStore(0);
+  const $second = app
+    .createStore(0)
+    .on(change, (state, payload) => state + payload);
+  const $third = app.createStore(0);
+
+  const $result = every({
+    predicate: (x) => x > 0,
+    stores: [$first, $second, $third],
+  });
+
+  const scopeA = fork(app);
+  const scopeB = fork(app);
+
+  await allSettled(change, {
+    scope: scopeA,
+    params: 1,
+  });
+
+  await allSettled(change, {
+    scope: scopeB,
+    params: 100,
+  });
+
+  await allSettled(change, {
+    scope: scopeA,
+    params: 1,
+  });
+
+  await allSettled(change, {
+    scope: scopeB,
+    params: 100,
+  });
+
+  expect(serialize(scopeA)).toMatchInlineSnapshot(`
+    Object {
+      "-jcx1ie": 0,
+      "66ukpz": 2,
+      "ryha7v": false,
+      "yheth1": 0,
+    }
+  `);
+  expect(serialize(scopeB)).toMatchInlineSnapshot(`
+    Object {
+      "-jcx1ie": 0,
+      "66ukpz": 200,
+      "ryha7v": false,
+      "yheth1": 0,
+    }
+  `);
+});
+
+test('throttle do not affect original store value', async () => {
+  const app = createDomain();
+  const change = app.createEvent<number>();
+  const $first = app.createStore(0);
+  const $second = app
+    .createStore(0)
+    .on(change, (state, payload) => state + payload);
+  const $third = app.createStore(0);
+
+  const $result = every({
+    predicate: (x) => x > 0,
+    stores: [$first, $second, $third],
+  });
+
+  const scope = fork(app);
+
+  await allSettled(change, {
+    scope,
+    params: 1,
+  });
+
+  await allSettled(change, {
+    scope,
+    params: 1,
+  });
+
+  expect(serialize(scope)).toMatchInlineSnapshot(`
+    Object {
+      "-4ovi4b": 0,
+      "-lvnp40": 0,
+      "kuw442": 2,
+      "ryha7v": false,
+    }
+  `);
+
+  expect($result.getState()).toMatchInlineSnapshot(`false`);
+});

--- a/every/every.test.js
+++ b/every/every.test.js
@@ -10,7 +10,7 @@ test('boolean predicate', () => {
   const $second = createStore(false).on(change, () => true);
   const $third = createStore(true);
 
-  const $result = every(true, [$first, $second, $third]);
+  const $result = every({ predicate: true, stores: [$first, $second, $third] });
 
   $result.watch(fn);
   expect(fn).toHaveBeenCalledWith(false);
@@ -32,7 +32,7 @@ test('number predicate', () => {
   const $second = createStore(2).on(change, () => 4);
   const $third = createStore(4);
 
-  const $result = every(4, [$first, $second, $third]);
+  const $result = every({ predicate: 4, stores: [$first, $second, $third] });
 
   $result.watch(fn);
   expect(fn).toHaveBeenCalledWith(false);
@@ -54,7 +54,10 @@ test('function predicate', () => {
   const $second = createStore(0).on(change, () => 5);
   const $third = createStore(3);
 
-  const $result = every((value) => value > 0, [$first, $second, $third]);
+  const $result = every({
+    predicate: (value) => value > 0,
+    stores: [$first, $second, $third],
+  });
 
   $result.watch(fn);
   expect(fn).toHaveBeenCalledWith(false);
@@ -75,7 +78,10 @@ test('initially true', () => {
   const $second = createStore(2);
   const $third = createStore(3);
 
-  const $result = every((value) => value > 0, [$first, $second, $third]);
+  const $result = every({
+    predicate: (value) => value > 0,
+    stores: [$first, $second, $third],
+  });
 
   $result.watch(fn);
   expect(fn).toHaveBeenCalledWith(true);

--- a/every/index.d.ts
+++ b/every/index.d.ts
@@ -1,13 +1,16 @@
 import { Store } from 'effector';
 
-export function every<T>(
-  predicate: (value: T) => boolean,
-  stores: Array<Store<T>>,
-): Store<boolean>;
+export function every<T>(_: {
+  predicate: (value: T) => boolean;
+  stores: Array<Store<T>>;
+}): Store<boolean>;
 
-export function every<T extends string>(
-  value: T,
-  stores: Array<Store<T>>,
-): Store<boolean>;
+export function every<T extends string>(_: {
+  predicate: T;
+  stores: Array<Store<T>>;
+}): Store<boolean>;
 
-export function every<T>(value: T, stores: Array<Store<T>>): Store<boolean>;
+export function every<T>(_: {
+  predicate: T;
+  stores: Array<Store<T>>;
+}): Store<boolean>;

--- a/every/index.js
+++ b/every/index.js
@@ -1,11 +1,14 @@
 const { combine } = require('effector');
+const { readConfig } = require('../library');
 
-function every(predicate, list) {
+function every(argument) {
+  const { predicate, stores } = readConfig(argument, ['predicate', 'stores']);
+
   const checker = isFunction(predicate)
     ? predicate
     : (value) => value === predicate;
 
-  return combine(list, (values) => values.every(checker));
+  return combine(stores, (values) => values.every(checker));
 }
 
 module.exports = { every };

--- a/every/readme.md
+++ b/every/readme.md
@@ -4,10 +4,10 @@
 import { every } from 'patronum/every';
 ```
 
-## `every(predicate, stores)`
+## `every({ predicate: Function, stores })`
 
 ```ts
-$result = every(predicate, stores);
+$result = every({ predicate: fn, stores });
 ```
 
 - `$result` will be `true` if each call `predicate` on each store value from `values` returns `true`, otherwise it will be `false`
@@ -27,22 +27,25 @@ $result = every(predicate, stores);
 const $width = createStore(440);
 const $height = createStore(780);
 
-const $fitsSquare = every((size) => size < 800, [$width, $height]);
+const $fitsSquare = every({
+  predicate: (size) => size < 800,
+  stores: [$width, $height],
+});
 
 console.assert(true === $fitsSquare.getState());
 ```
 
-## `every(value, stores)`
+## `every({ predicate: value, stores })`
 
 ```ts
-$result = every(value, stores);
+$result = every({ predicate: value, stores });
 ```
 
 - `$result` will be `true` if each value in `stores` equals `values`, otherwise it will be `false`
 
 ### Arguments
 
-1. `value` _(`T`)_ — Data to compare stores values with
+1. `predicate` _(`T`)_ — Data to compare stores values with
 1. `stores` _(`Array<Store<T>>`)_ — List of stores to compare with `value`
 1. type of `value` and `stores` should should be the same
 
@@ -56,7 +59,10 @@ $result = every(value, stores);
 const $isPasswordCorrect = createStore(true);
 const $isEmailCorrect = createStore(true);
 
-const $isFormCorrect = every(true, [$isPasswordCorrect, $isEmailCorrect]);
+const $isFormCorrect = every({
+  predicate: true,
+  stores: [$isPasswordCorrect, $isEmailCorrect],
+});
 
 console.assert(true === $isFormCorrect.getState());
 ```

--- a/test-d/every.ts
+++ b/test-d/every.ts
@@ -8,9 +8,9 @@ import { every } from '../every';
   const $b = createStore(1);
   const $invalid = createStore('');
 
-  expectType<Store<boolean>>(every(0, [$a, $b]));
+  expectType<Store<boolean>>(every({ predicate: 0, stores: [$a, $b] }));
 
-  expectError(every(0, [$a, $invalid]));
+  expectError(every({ predicate: 0, stores: [$a, $invalid] }));
 }
 
 // Check types for string enum
@@ -22,9 +22,9 @@ import { every } from '../every';
 
   const value: Enum = 'c';
 
-  expectType<Store<boolean>>(every(value, [$a, $b]));
-  expectError(every(value, [$a, $invalid]));
-  expectError(every('demo', [$a, $b]));
+  expectType<Store<boolean>>(every({ predicate: value, stores: [$a, $b] }));
+  expectError(every({ predicate: value, stores: [$a, $invalid] }));
+  expectError(every({ predicate: 'demo', stores: [$a, $b] }));
 }
 
 // Check function predicate
@@ -34,6 +34,6 @@ import { every } from '../every';
   const $b = createStore(1);
   const $invalid = createStore('');
 
-  expectType<Store<boolean>>(every(predicate, [$a, $b]));
-  expectError(every(predicate, [$a, $invalid]));
+  expectType<Store<boolean>>(every({ predicate, stores: [$a, $b] }));
+  expectError(every({ predicate, stores: [$a, $invalid] }));
 }


### PR DESCRIPTION
```ts
// before
const $result = every(true, [$a, $b, $c])
const $result = every(() => true, [$a, $b, $c])

// NOW
const $result = every({ predicate: true, stores: [$a, $b, $c] })
const $result = every({ predicate: () => true, stores: [$a, $b, $c] })
```

BREAKING CHANGE: removed `every(predicate, stores)` form

Closes #19 
Relates #27 