### PR TITLE
Implement object arguments form for `delay` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ import { createEvent } from 'effector';
 import { delay } from 'patronum/delay';
 
 const trigger = createEvent<string>(); // createStore or createEffect
-const delayed = delay(trigger, 300);
+
+// `timeout` also supports (payload) => number and Store<number>
+const delayed = delay({ source: trigger, timeout: 300 });
 
 delayed.watch((payload) => console.info('triggered', payload));
 

--- a/delay/delay.fork.test.ts
+++ b/delay/delay.fork.test.ts
@@ -1,0 +1,104 @@
+import 'regenerator-runtime/runtime';
+import { createDomain } from 'effector';
+import { fork, serialize, allSettled } from 'effector/fork';
+import { delay } from '.';
+
+test('throttle works in forked scope', async () => {
+  const app = createDomain();
+  const source = app.createEvent();
+
+  const $counter = app.createStore(0, { sid: '$counter' });
+
+  const throttled = delay({ source, timeout: 40 });
+
+  $counter.on(throttled, (value) => value + 1);
+
+  const scope = fork(app);
+
+  await allSettled(source, {
+    scope,
+    params: undefined,
+  });
+
+  expect(serialize(scope)).toMatchInlineSnapshot(`
+    Object {
+      "$counter": 1,
+    }
+  `);
+});
+
+test('throttle do not affect another forks', async () => {
+  const app = createDomain();
+  const $counter = app.createStore(0, { sid: '$counter' });
+
+  const trigger = app.createEvent<number>();
+
+  const throttled = delay({ source: trigger, timeout: 40 });
+
+  $counter.on(throttled, (value, payload) => value + payload);
+
+  const scopeA = fork(app);
+  const scopeB = fork(app);
+
+  await allSettled(trigger, {
+    scope: scopeA,
+    params: 1,
+  });
+
+  await allSettled(trigger, {
+    scope: scopeB,
+    params: 100,
+  });
+
+  await allSettled(trigger, {
+    scope: scopeA,
+    params: 1,
+  });
+
+  await allSettled(trigger, {
+    scope: scopeB,
+    params: 100,
+  });
+
+  expect(serialize(scopeA)).toMatchInlineSnapshot(`
+    Object {
+      "$counter": 2,
+    }
+  `);
+
+  expect(serialize(scopeB)).toMatchInlineSnapshot(`
+    Object {
+      "$counter": 200,
+    }
+  `);
+});
+
+test('throttle do not affect original store value', async () => {
+  const app = createDomain();
+  const $counter = app.createStore(0, { sid: '$counter' });
+  const trigger = app.createEvent<number>();
+
+  const throttled = delay({ source: trigger, timeout: 40 });
+
+  $counter.on(throttled, (value, payload) => value + payload);
+
+  const scope = fork(app);
+
+  await allSettled(trigger, {
+    scope,
+    params: 1,
+  });
+
+  await allSettled(trigger, {
+    scope,
+    params: 1,
+  });
+
+  expect(serialize(scope)).toMatchInlineSnapshot(`
+    Object {
+      "$counter": 2,
+    }
+  `);
+
+  expect($counter.getState()).toMatchInlineSnapshot(`0`);
+});

--- a/delay/index.d.ts
+++ b/delay/index.d.ts
@@ -1,7 +1,10 @@
-import { Unit, Event } from 'effector';
+import { Unit, Event, Store } from 'effector';
 
-export function delay<T>(unit: Unit<T>, time: number): Event<T>;
-export function delay<T>(
-  unit: Unit<T>,
-  options: { time: (payload: T) => number },
-): Event<T>;
+export function delay<T>(_: {
+  source: Unit<T>;
+  timeout: (payload: T) => number;
+}): Event<T>;
+export function delay<T>(_: {
+  source: Unit<T>;
+  timeout: Store<number> | number;
+}): Event<T>;

--- a/test-d/delay.ts
+++ b/test-d/delay.ts
@@ -1,0 +1,60 @@
+import { expectType, expectError } from 'tsd';
+import { Event, createStore } from 'effector';
+import { delay } from '../delay';
+
+// Check invalid type for source
+{
+  expectType<Event<string>>(delay({ source: createStore(''), timeout: 100 }));
+  expectType<Event<number>>(delay({ source: createStore(0), timeout: 100 }));
+
+  expectError<Event<number>>(delay({ source: createStore(''), timeout: 100 }));
+}
+
+// Check timeout type for number
+{
+  const source = createStore('');
+  expectType<Event<string>>(delay({ source, timeout: 100 }));
+
+  expectError(delay({ source, timeout: true }));
+  expectError(delay({ source, timeout: null }));
+  expectError(delay({ source, timeout: '' }));
+  expectError(delay({ source, timeout: Symbol() }));
+  expectError(delay({ source, timeout: undefined }));
+}
+
+// Check timeout type for function
+{
+  const source = createStore('');
+  expectType<Event<string>>(delay({ source, timeout: () => 0 }));
+
+  expectError(delay({ source, timeout: () => true }));
+  expectError(delay({ source, timeout: () => null }));
+  expectError(delay({ source, timeout: () => '' }));
+  expectError(delay({ source, timeout: () => Symbol() }));
+  expectError(delay({ source, timeout: () => undefined }));
+}
+
+// Check timeout type for function argument
+{
+  const source = createStore('');
+  expectType<Event<string>>(delay({ source, timeout: (p: string) => 0 }));
+
+  expectError(delay({ source, timeout: (p: number) => 0 }));
+  expectError(delay({ source, timeout: (p: null) => 0 }));
+  expectError(delay({ source, timeout: (p: undefined) => 0 }));
+  expectError(delay({ source, timeout: (p: symbol) => 0 }));
+  expectError(delay({ source, timeout: (p: object) => 0 }));
+  expectError(delay({ source, timeout: (p: Function) => 0 }));
+}
+
+// Check timeout type for store
+{
+  const source = createStore('');
+  expectType<Event<string>>(delay({ source, timeout: createStore(0) }));
+
+  expectError(delay({ source, timeout: createStore(true) }));
+  expectError(delay({ source, timeout: createStore(null) }));
+  expectError(delay({ source, timeout: createStore('') }));
+  expectError(delay({ source, timeout: createStore(Symbol()) }));
+  expectError(delay({ source, timeout: createStore(undefined) }));
+}


### PR DESCRIPTION
```ts
// before
const delayed = delay(unit, 100);

const logDelayed = delay(unit, { time: (payload) => 100 });

// NOW
const delayed = delay({
  source: unit,
  timeout: 100,
})

const delayed = delay({
  source: unit,
  timeout: (payload) => 100,
})

const delayed = delay({
  source: unit,
  timeout: $timeout,
})
```

### Feature
- Added support for `Store<number>` for `timeout`

BREAKING CHANGE: removed `delay(source, { time })`

Closes #46
Relates #27
Relates #22