### PR TITLE
Fix broken types in `status` method

### DIFF
--- a/status/index.d.ts
+++ b/status/index.d.ts
@@ -3,6 +3,6 @@ import { Store, Effect } from 'effector';
 type Status = 'initial' | 'pending' | 'done' | 'fail';
 
 export function status<Params, Result>(
-  effect: Effect<P, R>,
+  effect: Effect<Params, Result>,
   initialValue?: Status,
 ): Store<Status>;


### PR DESCRIPTION
Fix typecheck errors:
```
ERROR in .../node_modules/patronum/status/index.d.ts(6,18):
TS2304: Cannot find name 'P'.
ERROR in .../node_modules/patronum/status/index.d.ts(6,21):
TS2304: Cannot find name 'R'.
```