### PR TITLE
Add object arguments form for `reshape` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,10 +243,13 @@ import { reshape } from 'patronum/reshape';
 
 const $original = createStore<string>('Hello world');
 
-const parts = reshape($original, {
-  length: (string) => string.length,
-  first: (string) => string.split(' ')[0] || '',
-  second: (string) => string.split(' ')[1] || '',
+const parts = reshape({
+  source: $original,
+  shape: {
+    length: (string) => string.length,
+    first: (string) => string.split(' ')[0] || '',
+    second: (string) => string.split(' ')[1] || '',
+  },
 });
 
 parts.length.watch(console.info); // 11

--- a/reshape/index.d.ts
+++ b/reshape/index.d.ts
@@ -1,6 +1,6 @@
 import { Store } from 'effector';
 
-export function reshape<T, S extends {}>(
-  store: Store<T>,
-  shape: { [K in keyof S]: (v: T) => S[K] },
-): { [K in keyof S]: Store<S[K]> };
+export function reshape<Type, Shape extends {}>(_: {
+  source: Store<Type>;
+  shape: { [ShapeKey in keyof Shape]: (value: Type) => Shape[ShapeKey] };
+}): { [ResultKey in keyof Shape]: Store<Shape[ResultKey]> };

--- a/reshape/index.js
+++ b/reshape/index.js
@@ -1,9 +1,12 @@
-function reshape(store, shape) {
+const { readConfig } = require('../library');
+
+function reshape(argument) {
+  const { source, shape } = readConfig(argument, ['source', 'shape']);
   const result = {};
 
   for (const key in shape) {
     if (key in shape) {
-      result[key] = store.map(shape[key]);
+      result[key] = source.map(shape[key]);
     }
   }
 

--- a/reshape/readme.md
+++ b/reshape/readme.md
@@ -7,10 +7,10 @@ import { reshape } from 'patronum/reshape';
 ## Formulae
 
 ```ts
-shape = reshape(store, cases);
+result = reshape(source, shape);
 ```
 
-- Call each function in `cases` object with data from `store`, and create store with the same name as key in `cases`
+- Call each function in `shape` object with data from `source`, and create store with the same name as key in `shape`
 
 > No arguments yet
 
@@ -22,16 +22,19 @@ import { reshape } from 'patronum/reshape';
 
 const $original = createStore<string>('Example');
 
-const shape = reshape($original, {
-  length: (string) => string.length,
-  lowercase: (string) => string.toLowerCase(),
-  uppercase: (string) => string.toUpperCase(),
+const result = reshape({
+  source: $original,
+  shape: {
+    length: (string) => string.length,
+    lowercase: (string) => string.toLowerCase(),
+    uppercase: (string) => string.toUpperCase(),
+  },
 });
 
-// shape.length: Store<number>;
-// shape.lowercase: Store<string>;
-// shape.uppercase: Store<string>;
+// result.length: Store<number>;
+// result.lowercase: Store<string>;
+// result.uppercase: Store<string>;
 
-shape.length.watch((length) => console.log('String length:', length));
-shape.lowercase.watch((lowercase) => console.log('lowercase:', lowercase));
+result.length.watch((length) => console.log('String length:', length));
+result.lowercase.watch((lowercase) => console.log('lowercase:', lowercase));
 ```

--- a/reshape/reshape.test.js
+++ b/reshape/reshape.test.js
@@ -4,10 +4,13 @@ const { reshape } = require('./index');
 test('reshape from string to different types', () => {
   const $original = createStore('some long value');
 
-  const shape = reshape($original, {
-    length: (original) => original.length,
-    uppercase: (original) => original.toUpperCase(),
-    hasSpace: (original) => original.includes(' '),
+  const shape = reshape({
+    source: $original,
+    shape: {
+      length: (original) => original.length,
+      uppercase: (original) => original.toUpperCase(),
+      hasSpace: (original) => original.includes(' '),
+    },
   });
 
   expect(shape.length.getState()).toBe(15);
@@ -20,10 +23,13 @@ test('reshaped stores updates correctly', () => {
   const update = createEvent();
   $original.on(update, (_, v) => v);
 
-  const shape = reshape($original, {
-    length: (original) => original.length,
-    uppercase: (original) => original.toUpperCase(),
-    hasSpace: (original) => original.includes(' '),
+  const shape = reshape({
+    source: $original,
+    shape: {
+      length: (original) => original.length,
+      uppercase: (original) => original.toUpperCase(),
+      hasSpace: (original) => original.includes(' '),
+    },
   });
 
   expect(shape.length.getState()).toBe(15);
@@ -40,10 +46,13 @@ test('reshaped stores updates correctly', () => {
 test('reshape ejects values from object', () => {
   const $user = createStore({ id: 1, name: 'Sergey', surname: 'Sova' });
 
-  const shape = reshape($user, {
-    id: (user) => user.id,
-    name: (user) => user.name,
-    surname: (user) => user.surname,
+  const shape = reshape({
+    source: $user,
+    shape: {
+      id: (user) => user.id,
+      name: (user) => user.name,
+      surname: (user) => user.surname,
+    },
   });
 
   expect(shape.id.getState()).toBe(1);


### PR DESCRIPTION
```ts
// Before
const parts = reshape($original, {
  length: (string) => string.length,
  first: (string) => string.split(' ')[0] || '',
  second: (string) => string.split(' ')[1] || '',
});

// NOW
const parts = reshape({
  source: $original,
  shape: {
    length: (string) => string.length,
    first: (string) => string.split(' ')[0] || '',
    second: (string) => string.split(' ')[1] || '',
  },
});
```

BREAKING CHANGE: remove `reshape(source, {})`