### PR TITLE
Add object arguments form for `combineEvents`

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,9 +199,11 @@ const event2 = createEvent();
 const event3 = createEvent();
 
 const event = combineEvents({
-  event1,
-  event2,
-  event3,
+  events: {
+    event1,
+    event2,
+    event3,
+  },
 });
 
 event.watch((object) => console.log('triggered', object));

--- a/combine-events/combine-events.test.js
+++ b/combine-events/combine-events.test.js
@@ -13,11 +13,13 @@ test('source: shape', () => {
   const event5 = createEvent();
 
   const event = combineEvents({
-    event1,
-    event2,
-    event3,
-    event4,
-    event5,
+    events: {
+      event1,
+      event2,
+      event3,
+      event4,
+      event5,
+    },
   });
 
   event.watch(fn);
@@ -145,7 +147,9 @@ test('source: array', () => {
   const event4 = createEvent();
   const event5 = createEvent();
 
-  const event = combineEvents([event1, event2, event3, event4, event5]);
+  const event = combineEvents({
+    events: [event1, event2, event3, event4, event5],
+  });
 
   event.watch(fn);
 
@@ -213,9 +217,11 @@ test('example from readme', () => {
   const event3 = createEvent();
 
   const event = combineEvents({
-    event1,
-    event2,
-    event3,
+    events: {
+      event1,
+      event2,
+      event3,
+    },
   });
 
   event.watch(fn);

--- a/combine-events/index.d.ts
+++ b/combine-events/index.d.ts
@@ -1,12 +1,12 @@
 import { Event, Tuple } from 'effector';
 
-export function combineEvents<Shape extends Tuple>(
-  shape: Shape,
-): Event<
-  { [K in keyof Shape]: Shape[K] extends Event<infer U> ? U : Shape[K] }
+export function combineEvents<Shape extends Tuple>(_: {
+  events: Shape;
+}): Event<
+  { [Key in keyof Shape]: Shape[Key] extends Event<infer U> ? U : Shape[Key] }
 >;
-export function combineEvents<Shape>(
-  shape: Shape,
-): Event<
-  { [K in keyof Shape]: Shape[K] extends Event<infer U> ? U : Shape[K] }
+export function combineEvents<Shape>(_: {
+  events: Shape;
+}): Event<
+  { [Key in keyof Shape]: Shape[Key] extends Event<infer U> ? U : Shape[Key] }
 >;

--- a/combine-events/readme.md
+++ b/combine-events/readme.md
@@ -4,14 +4,16 @@
 import { combineEvents } from 'patronum/combine-events';
 ```
 
-## `combineEvents(object)`
+## `combineEvents({ events: Record<key, Event<T>> })`
 
 ### Formulae
 
 ```ts
 const target = combineEvents({
-  key1: event1,
-  key2: event2,
+  events: {
+    key1: event1,
+    key2: event2,
+  },
 });
 ```
 
@@ -25,9 +27,11 @@ const second = createEvent<string>();
 const third = createEvent<boolean>();
 
 const target = combineEvents({
-  a: first,
-  second,
-  another: third,
+  events: {
+    a: first,
+    second,
+    another: third,
+  },
 });
 
 target.watch((object) => {
@@ -41,12 +45,12 @@ second('wow'); // nothing
 third(false); // target triggered with object
 ```
 
-## `combineEvents(array)`
+## `combineEvents({ events: Array<Event<T>> })`
 
 ### Formulae
 
 ```ts
-const target = combineEvents([event1, event2]);
+const target = combineEvents({ events: [event1, event2] });
 ```
 
 - When all events (`event1` and `event2` from example) is triggered, trigger `target` with array from events with the same order as events
@@ -58,7 +62,7 @@ const first = createEvent<number>();
 const second = createEvent<string>();
 const third = createEvent<boolean>();
 
-const target = combineEvents([first, second, third]);
+const target = combineEvents({ events: [first, second, third] });
 
 target.watch((list) => {
   console.log('first event data', list[0]);


### PR DESCRIPTION
```ts
// Before
const target = combineEvents([first, second, third]);
const target = combineEvents({
  key1: event1,
  key2: event2,
});

// NOW
const target = combineEvents({ events: [first, second, third] });
const target = combineEvents({
  events: {
    key1: event1,
    key2: event2,
  },
});

```

BREAKING CHANGE: removed `combineEvent(events)`

Closes #58 