### PR TITLE
Add object arguments form for `spread` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,9 +175,12 @@ const trigger = createEvent<{ first: string; second: string }>();
 const $first = createStore('');
 const $second = createStore('');
 
-spread(trigger, {
-  first: $first,
-  second: $second,
+spread({
+  source: trigger,
+  targets: {
+    first: $first,
+    second: $second,
+  },
 });
 
 trigger({ first: 'Hello', second: 'World' });

--- a/spread/index.d.ts
+++ b/spread/index.d.ts
@@ -1,5 +1,5 @@
 import {} from 'effector';
 
 // TODO: should be typed
-export function spread(source: any, cases: any): void;
-export function spread(cases: any): void;
+export function spread(_: { source: any; targets: any }): void;
+export function spread(_: { targets: any }): void;

--- a/spread/index.js
+++ b/spread/index.js
@@ -1,29 +1,34 @@
 /* eslint-disable no-param-reassign */
 const { createEvent, sample, guard } = require('effector');
+const { readConfig } = require('../library');
 
 /**
- * @examle
- * spread(dataObject, { first: targetA, second: targetB })
+ * @example
+ * spread({ source: dataObject, targets: { first: targetA, second: targetB } })
  * forward({
- *   to: spread({ first: targetA, second: targetB })
+ *   to: spread({targets: { first: targetA, second: targetB } })
  * })
  */
-function spread(source, targetCases) {
-  if (targetCases === undefined) {
-    targetCases = source;
-    source = createEvent();
-  }
-  for (const key in targetCases) {
-    if (key in targetCases) {
-      const correctKey = guard(source, {
-        filter: (data) =>
-          typeof data === 'object' && data !== null && key in data,
+function spread(argument) {
+  const {
+    loc,
+    name = 'unknown',
+    source = createEvent({ loc, name: `${name}Source` }),
+    targets,
+  } = readConfig(argument, ['loc', 'name', 'source', 'targets']);
+
+  for (const targetKey in targets) {
+    if (targetKey in targets) {
+      const hasTargetKey = guard({
+        source,
+        filter: (object) =>
+          typeof object === 'object' && object !== null && targetKey in object,
       });
 
       sample({
-        source: correctKey,
-        fn: (data) => data[key],
-        target: targetCases[key],
+        source: hasTargetKey,
+        fn: (object) => object[targetKey],
+        target: targets[targetKey],
       });
     }
   }

--- a/spread/readme.md
+++ b/spread/readme.md
@@ -4,12 +4,12 @@
 import { spread } from 'patronum/spread';
 ```
 
-## `spread(source, targets)`
+## `spread({ source, targets })`
 
 ### Formulae
 
 ```ts
-spread(source, { field: target, ... })
+spread({ source, targets: { field: target, ... } })
 ```
 
 - When `source` is triggered with **object**, extract `field` from data, and trigger `target`
@@ -35,9 +35,12 @@ const $last = createStore('');
 
 const formReceived = createEvent();
 
-spread(formReceived, {
-  first: $first,
-  last: $last,
+spread({
+  source: formReceived,
+  targets: {
+    first: $first,
+    last: $last,
+  },
 });
 
 $first.watch((first) => console.log('First name', first));
@@ -63,9 +66,12 @@ const $form = createStore(null).on(save, (_, form) => form);
 const firstNameChanged = createEvent();
 const lastNameChanged = createEvent();
 
-spread($form, {
-  first: firstNameChanged,
-  last: lastNameChanged,
+spread({
+  source: $form,
+  targets: {
+    first: firstNameChanged,
+    last: lastNameChanged,
+  },
 });
 
 firstNameChanged.watch((first) => console.log('First name', first));
@@ -79,10 +85,10 @@ save(null);
 // Nothing, because store is null
 ```
 
-## `spread(targets)`
+## `spread({ targets })`
 
 ```ts
-source = spread({ field: target, ... })
+source = spread({ targets: { field: target, ... } })
 ```
 
 - When `source` is triggered with **object**, extract `field` from data, and trigger `target`
@@ -115,8 +121,10 @@ guard({
   source: formReceived,
   filter: (form) => form.first.length > 0 && form.last.length > 0,
   target: spread({
-    first: $first,
-    last: $last,
+    targets: {
+      first: $first,
+      last: $last,
+    },
   }),
 });
 
@@ -140,12 +148,17 @@ const $targetA = createStore('');
 const $targetB = createStore(0);
 const $targetC = createStore(false);
 
-spread(trigger, {
-  first: $targetA,
-  second: spread({
-    foo: $targetB,
-    bar: $targetC,
-  }),
+spread({
+  source: trigger,
+  targets: {
+    first: $targetA,
+    second: spread({
+      targets: {
+        foo: $targetB,
+        bar: $targetC,
+      },
+    }),
+  },
 });
 
 $targetA.watch((payload) => console.log('targetA', payload));

--- a/spread/spread.test.js
+++ b/spread/spread.test.js
@@ -13,9 +13,12 @@ describe('spread(source, targets)', () => {
     targetA.watch(fnA);
     targetB.watch(fnB);
 
-    spread(source, {
-      first: targetA,
-      second: targetB,
+    spread({
+      source,
+      targets: {
+        first: targetA,
+        second: targetB,
+      },
     });
 
     source({ first: 'Hello', second: 200 });
@@ -34,9 +37,12 @@ describe('spread(source, targets)', () => {
     targetA.watch(fnA);
     targetB.watch(fnB);
 
-    spread(source, {
-      first: targetA,
-      second: targetB,
+    spread({
+      source,
+      targets: {
+        first: targetA,
+        second: targetB,
+      },
     });
 
     source({ first: 'Hello', second: 200 });
@@ -59,9 +65,12 @@ describe('spread(source, targets)', () => {
     targetA.watch(fnA);
     targetB.watch(fnB);
 
-    spread(source, {
-      first: targetA,
-      second: targetB,
+    spread({
+      source,
+      targets: {
+        first: targetA,
+        second: targetB,
+      },
     });
 
     change({ first: 'Hello', second: 200 });
@@ -84,9 +93,12 @@ describe('spread(source, targets)', () => {
     targetA.watch(fnA);
     targetB.watch(fnB);
 
-    spread(source, {
-      first: targetA,
-      second: targetB,
+    spread({
+      source,
+      targets: {
+        first: targetA,
+        second: targetB,
+      },
     });
 
     change({ first: 'Hello', second: 200 });
@@ -110,8 +122,10 @@ describe('spread(targets)', () => {
     forward({
       from: source,
       to: spread({
-        first: targetA,
-        second: targetB,
+        targets: {
+          first: targetA,
+          second: targetB,
+        },
       }),
     });
 
@@ -134,8 +148,10 @@ describe('spread(targets)', () => {
     forward({
       from: source,
       to: spread({
-        first: targetA,
-        second: targetB,
+        targets: {
+          first: targetA,
+          second: targetB,
+        },
       }),
     });
 
@@ -162,8 +178,10 @@ describe('spread(targets)', () => {
     forward({
       from: source,
       to: spread({
-        first: targetA,
-        second: targetB,
+        targets: {
+          first: targetA,
+          second: targetB,
+        },
       }),
     });
 
@@ -190,8 +208,10 @@ describe('spread(targets)', () => {
     forward({
       from: source,
       to: spread({
-        first: targetA,
-        second: targetB,
+        targets: {
+          first: targetA,
+          second: targetB,
+        },
       }),
     });
 
@@ -213,9 +233,12 @@ describe('edge', () => {
     targetA.watch(fnA);
     targetB.watch(fnB);
 
-    spread(source, {
-      0: targetA,
-      1: targetB,
+    spread({
+      source,
+      targets: {
+        0: targetA,
+        1: targetB,
+      },
     });
 
     source(['Hello', 200]);
@@ -237,12 +260,17 @@ describe('edge', () => {
     targetB.watch(fnB);
     targetC.watch(fnC);
 
-    spread(source, {
-      first: targetA,
-      second: spread({
-        foo: targetB,
-        bar: targetC,
-      }),
+    spread({
+      source,
+      targets: {
+        first: targetA,
+        second: spread({
+          targets: {
+            foo: targetB,
+            bar: targetC,
+          },
+        }),
+      },
     });
 
     source({
@@ -270,9 +298,12 @@ describe('invalid', () => {
     targetA.watch(fnA);
     targetB.watch(fnB);
 
-    spread(source, {
-      first: targetA,
-      second: targetB,
+    spread({
+      source,
+      targets: {
+        first: targetA,
+        second: targetB,
+      },
     });
 
     source({ second: 200 });
@@ -291,9 +322,12 @@ describe('invalid', () => {
     targetA.watch(fnA);
     targetB.watch(fnB);
 
-    spread(source, {
-      first: targetA,
-      second: targetB,
+    spread({
+      source,
+      targets: {
+        first: targetA,
+        second: targetB,
+      },
     });
 
     source({});
@@ -312,9 +346,12 @@ describe('invalid', () => {
     targetA.watch(fnA);
     targetB.watch(fnB);
 
-    spread(source, {
-      first: targetA,
-      second: targetB,
+    spread({
+      source,
+      targets: {
+        first: targetA,
+        second: targetB,
+      },
     });
 
     source(null);
@@ -334,9 +371,12 @@ describe('invalid', () => {
     targetA.watch(fnA);
     targetB.watch(fnB);
 
-    spread(source, {
-      first: targetA,
-      second: targetB,
+    spread({
+      source,
+      targets: {
+        first: targetA,
+        second: targetB,
+      },
     });
 
     source();


### PR DESCRIPTION
```ts
// Before
spread(formReceived, {
  first: $first,
  last: $last,
});

const source = spread({
  first: $first,
  last: $last,
});

// NOW
spread({
  source: formReceived,
  targets: {
    first: $first,
    last: $last,
  },
});

const source = spread({
  targets: {
    first: $first,
    last: $last,
  },
});

```

BREAKING CHANGE: removed `spread(source, targets)` and `source = spread(targets)`

Closes #45
Closes #4