### PR TITLE
Add migration guide `v0.14` → `v0.100`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,342 @@
+# Migration guide from `v0.14+`
+
+<details>
+<summary><strong><code>throttle</code></strong></summary>
+
+```ts
+import { throttle } from 'patronum/throttle';
+```
+
+### Previous version
+
+```ts
+const throttled = throttle(source, timeout);
+```
+
+### Current version
+
+```ts
+const throttled = throttle({ source, timeout });
+
+// Also you can set target
+const throttled = createEvent(); // or any unit
+throttle({ source, timeout, target: throttled });
+```
+
+- Wrap `source` and `timeout` arguments to object
+- Optionally add `target` parameter
+
+https://github.com/sergeysova/patronum/pull/31
+
+</details>
+
+<details>
+<summary><strong><code>debounce</code></strong></summary>
+
+```ts
+import { debounce } from 'patronum/debounce';
+```
+
+### Previous version
+
+```ts
+const debounced = debounce(source, timeout);
+```
+
+### Current version
+
+```ts
+const debounced = debounce({ source, timeout });
+
+// Also you can set target
+const debounced = createEvent(); // or any unit
+debounce({ source, timeout, target: debounced });
+```
+
+- Wrap `source` and `timeout` arguments to object
+- Optionally add `target` parameter
+
+https://github.com/sergeysova/patronum/pull/38
+
+</details>
+
+<details>
+<summary><strong><code>splitMap</code></strong></summary>
+
+```ts
+import { splitMap } from 'patronum/split-map';
+```
+
+### Previous version
+
+```ts
+const received = splitMap(nameReceived, {
+  firstName: (string) => string.split(' ')[0], // string | undefined
+  lastName: (string) => string.split(' ')[1], // string | undefined
+});
+```
+
+### Current version
+
+```ts
+const received = splitMap({
+  source: nameReceived,
+  cases: {
+    firstName: (string) => string.split(' ')[0], // string | undefined
+    lastName: (string) => string.split(' ')[1], // string | undefined
+});
+```
+
+- First argument should be `source`
+- Second argument should be `cases`
+
+https://github.com/sergeysova/patronum/pull/41
+
+</details>
+
+<details>
+<summary><strong><code>some</code></strong></summary>
+
+```ts
+import { some } from 'patronum/some';
+```
+
+### Previous version
+
+```ts
+const $tooBig = some((size) => size > 800, [$width, $height]);
+```
+
+### Current version
+
+```ts
+const $tooBig = some({
+  predicate: (size) => size > 800,
+  stores: [$width, $height],
+});
+```
+
+- First argument should be `predicate`
+- Second argument should be `stores`
+
+https://github.com/sergeysova/patronum/pull/43
+
+</details>
+
+<details>
+<summary><strong><code>every</code></strong></summary>
+
+```ts
+import { every } from 'patronum/every';
+```
+
+### Previous version
+
+```ts
+const $result = every(true, [$a, $b, $c]);
+const $result = every(() => true, [$a, $b, $c]);
+```
+
+### Current version
+
+```ts
+const $result = every({ predicate: true, stores: [$a, $b, $c] });
+const $result = every({ predicate: () => true, stores: [$a, $b, $c] });
+```
+
+- First argument should be `predicate`
+- Second argument should be `stores`
+
+https://github.com/sergeysova/patronum/pull/50
+
+</details>
+
+<details>
+<summary><strong><code>delay</code></strong></summary>
+
+```ts
+import { delay } from 'patronum/delay';
+```
+
+### Previous version
+
+```ts
+const delayed = delay(unit, 100);
+const logDelayed = delay(unit, { time: (payload) => 100 });
+```
+
+### Current version
+
+```ts
+const delayed = delay({
+  source: unit,
+  timeout: 100,
+});
+
+const delayed = delay({
+  source: unit,
+  timeout: (payload) => 100,
+});
+
+const delayed = delay({
+  source: unit,
+  timeout: $timeout,
+});
+```
+
+- First argument should be `source`
+- Second argument should be `timeout`
+- `time` property from second argument should be `timeout`
+- `timeout` can be `Store<number>`
+
+https://github.com/sergeysova/patronum/pull/51
+
+</details>
+
+<details>
+<summary><strong><code>status</code></strong></summary>
+
+```ts
+import { status } from 'patronum/status';
+```
+
+### Previous version
+
+```ts
+const $status = status(effect, 'initial');
+```
+
+### Current version
+
+```ts
+const $status = status({ effect, defaultValue: 'initial' });
+```
+
+- First argument should be `effect` in object
+- Second argument should be `defaultValue` and can be optional
+
+https://github.com/sergeysova/patronum/pull/55
+
+</details>
+
+<details>
+<summary><strong><code>reshape</code></strong></summary>
+
+```ts
+import { reshape } from 'patronum/reshape';
+```
+
+### Previous version
+
+```ts
+const parts = reshape($original, {
+  length: (string) => string.length,
+  first: (string) => string.split(' ')[0] || '',
+  second: (string) => string.split(' ')[1] || '',
+});
+```
+
+### Current version
+
+```ts
+const parts = reshape({
+  source: $original,
+  shape: {
+    length: (string) => string.length,
+    first: (string) => string.split(' ')[0] || '',
+    second: (string) => string.split(' ')[1] || '',
+  },
+});
+```
+
+- First argument should be `source`
+- Second argument should be `shape`
+
+https://github.com/sergeysova/patronum/pull/57
+
+</details>
+
+<details>
+<summary><strong><code>combineEvents</code></strong></summary>
+
+```ts
+import { combineEvents } from 'patronum/combine-events';
+```
+
+### Previous version
+
+```ts
+const target = combineEvents([first, second, third]);
+const target = combineEvents({
+  key1: event1,
+  key2: event2,
+});
+```
+
+### Current version
+
+```ts
+const target = combineEvents({ events: [first, second, third] });
+const target = combineEvents({
+  events: {
+    key1: event1,
+    key2: event2,
+  },
+});
+```
+
+- Assign first argument to property `events` in object
+
+https://github.com/sergeysova/patronum/pull/58
+
+</details>
+
+<details>
+<summary><strong><code>spread</code></strong></summary>
+
+```ts
+import { spread } from 'patronum/spread';
+```
+
+### Previous version
+
+```ts
+spread(formReceived, {
+  first: $first,
+  last: $last,
+});
+
+const source = spread({
+  first: $first,
+  last: $last,
+});
+```
+
+### Current version
+
+```ts
+spread({
+  source: formReceived,
+  targets: {
+    first: $first,
+    last: $last,
+  },
+});
+
+const source = spread({
+  targets: {
+    first: $first,
+    last: $last,
+  },
+});
+```
+
+1. If you have two arguments:
+   - First argument should be `source` in object
+   - Second argument should be `targets`
+1. If only one argument:
+   - Wrap it to object and assign to `targets`
+
+https://github.com/sergeysova/patronum/pull/61
+
+</details>

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -15,13 +15,13 @@ yarn add patronum@next
 import { throttle } from 'patronum/throttle';
 ```
 
-### Previous version
+### Previous version `v0.14.x`
 
 ```ts
 const throttled = throttle(source, timeout);
 ```
 
-### Current version
+### Current version `v0.102.x`
 
 ```ts
 const throttled = throttle({ source, timeout });
@@ -45,13 +45,13 @@ https://github.com/sergeysova/patronum/pull/31
 import { debounce } from 'patronum/debounce';
 ```
 
-### Previous version
+### Previous version `v0.14.x`
 
 ```ts
 const debounced = debounce(source, timeout);
 ```
 
-### Current version
+### Current version `v0.102.x`
 
 ```ts
 const debounced = debounce({ source, timeout });
@@ -75,7 +75,7 @@ https://github.com/sergeysova/patronum/pull/38
 import { splitMap } from 'patronum/split-map';
 ```
 
-### Previous version
+### Previous version `v0.14.x`
 
 ```ts
 const received = splitMap(nameReceived, {
@@ -84,7 +84,7 @@ const received = splitMap(nameReceived, {
 });
 ```
 
-### Current version
+### Current version `v0.102.x`
 
 ```ts
 const received = splitMap({
@@ -109,13 +109,13 @@ https://github.com/sergeysova/patronum/pull/41
 import { some } from 'patronum/some';
 ```
 
-### Previous version
+### Previous version `v0.14.x`
 
 ```ts
 const $tooBig = some((size) => size > 800, [$width, $height]);
 ```
 
-### Current version
+### Current version `v0.102.x`
 
 ```ts
 const $tooBig = some({
@@ -138,14 +138,14 @@ https://github.com/sergeysova/patronum/pull/43
 import { every } from 'patronum/every';
 ```
 
-### Previous version
+### Previous version `v0.14.x`
 
 ```ts
 const $result = every(true, [$a, $b, $c]);
 const $result = every(() => true, [$a, $b, $c]);
 ```
 
-### Current version
+### Current version `v0.102.x`
 
 ```ts
 const $result = every({ predicate: true, stores: [$a, $b, $c] });
@@ -166,14 +166,14 @@ https://github.com/sergeysova/patronum/pull/50
 import { delay } from 'patronum/delay';
 ```
 
-### Previous version
+### Previous version `v0.14.x`
 
 ```ts
 const delayed = delay(unit, 100);
 const logDelayed = delay(unit, { time: (payload) => 100 });
 ```
 
-### Current version
+### Current version `v0.102.x`
 
 ```ts
 const delayed = delay({
@@ -208,13 +208,13 @@ https://github.com/sergeysova/patronum/pull/51
 import { status } from 'patronum/status';
 ```
 
-### Previous version
+### Previous version `v0.14.x`
 
 ```ts
 const $status = status(effect, 'initial');
 ```
 
-### Current version
+### Current version `v0.102.x`
 
 ```ts
 const $status = status({ effect, defaultValue: 'initial' });
@@ -234,7 +234,7 @@ https://github.com/sergeysova/patronum/pull/55
 import { reshape } from 'patronum/reshape';
 ```
 
-### Previous version
+### Previous version `v0.14.x`
 
 ```ts
 const parts = reshape($original, {
@@ -244,7 +244,7 @@ const parts = reshape($original, {
 });
 ```
 
-### Current version
+### Current version `v0.102.x`
 
 ```ts
 const parts = reshape({
@@ -271,7 +271,7 @@ https://github.com/sergeysova/patronum/pull/57
 import { combineEvents } from 'patronum/combine-events';
 ```
 
-### Previous version
+### Previous version `v0.14.x`
 
 ```ts
 const target = combineEvents([first, second, third]);
@@ -281,7 +281,7 @@ const target = combineEvents({
 });
 ```
 
-### Current version
+### Current version `v0.102.x`
 
 ```ts
 const target = combineEvents({ events: [first, second, third] });
@@ -306,7 +306,7 @@ https://github.com/sergeysova/patronum/pull/58
 import { spread } from 'patronum/spread';
 ```
 
-### Previous version
+### Previous version `v0.14.x`
 
 ```ts
 spread(formReceived, {
@@ -320,7 +320,7 @@ const source = spread({
 });
 ```
 
-### Current version
+### Current version `v0.102.x`
 
 ```ts
 spread({

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,13 @@
 # Migration guide from `v0.14+`
 
+```shell
+npm install patronum@next
+```
+
+```shell
+yarn add patronum@next
+```
+
 <details>
 <summary><strong><code>throttle</code></strong></summary>
 

--- a/README.md
+++ b/README.md
@@ -35,11 +35,17 @@ import { delay } from 'patronum/delay';
 
 Also use can import it from index:
 
-> Be careful, with this method, all functions will be at your bundle
+> Be careful, with this import method, all functions will be at your bundle
 
 ```ts
 import { delay } from 'patronum';
 ```
+
+## Migration guide
+
+From `v0.100.0` patronum introduced object arguments form with **BREAKING CHANGES**. Please, review [migration guide](./MIGRATION.md) before upgrade from `v0.14.x` on your project.
+
+---
 
 ## [Condition](/condition 'Documentation')
 


### PR DESCRIPTION
**[Rendered](https://github.com/sergeysova/patronum/blob/docs/migration-guide/MIGRATION.md)**

Steps after merge:
- [ ] Release `v0.102.1` — for the migration guide appear on npmjs.com
- [ ] Deprecate `v0.14.0` and `v0.14.1` — add a link to migration guide to deprecate notice
- [ ] 14 Jule — sync `next` and `latest` npm tags