### PR TITLE
fix `combineEvents` fires again after reset

### DIFF
--- a/src/combine-events/combine-events.test.ts
+++ b/src/combine-events/combine-events.test.ts
@@ -1014,3 +1014,48 @@ test('target', () => {
     ]
   `);
 });
+
+test('bug: triggers correctly after reset', () => {
+  const fn = jest.fn();
+  const initArr = createEvent<number[]>();
+  const changeArr = createEvent<number[]>();
+  const anotherChangeArr = createEvent<number[]>();
+
+  const $arr = restore(initArr, []).on(anotherChangeArr, (_, arr) => arr);
+
+  const changedCombined = combineEvents({
+    events: { set: changeArr, updates: $arr.updates },
+    reset: initArr,
+  });
+
+  changedCombined.watch(fn);
+
+  changeArr([1]);
+  anotherChangeArr([2]);
+
+  initArr([]);
+
+  changeArr([3]);
+  anotherChangeArr([4]);
+
+  expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    [
+      {
+        "set": [
+          1,
+        ],
+        "updates": [
+          2,
+        ],
+      },
+      {
+        "set": [
+          3,
+        ],
+        "updates": [
+          4,
+        ],
+      },
+    ]
+  `);
+});

--- a/src/combine-events/index.ts
+++ b/src/combine-events/index.ts
@@ -74,7 +74,7 @@ export function combineEvents<P>(
 
     if (reset) {
       sample({ source: reset, target: $counter.reinit });
-      $results.reset(reset);
+      sample({ source: reset, target: $results.reinit });
     }
 
     for (const key of keys) {
@@ -83,10 +83,11 @@ export function combineEvents<P>(
         .reset(target);
 
       if (reset) {
-        $isDone.reset(reset);
+        sample({ source: reset, target: $isDone.reinit });
       }
 
-      $counter.on($isDone, (value) => value - 1);
+      $counter.on($isDone, (value, isDone) => (isDone ? value - 1 : value));
+
       $results.on(events[key], (shape, payload) => {
         const newShape = (Array.isArray(shape) ? [...shape] : { ...shape }) as any;
         newShape[key] = payload;


### PR DESCRIPTION
### Description

`combineEvents` previously stopped working after a reset had been hit.
This behaviour is fixed and a test is added