### PR TITLE
bugfix interval

### DIFF
--- a/src/interval/index.ts
+++ b/src/interval/index.ts
@@ -140,7 +140,12 @@ export function interval<S extends unknown, F extends unknown>({
     clock: teardown,
     target: cleanupFx,
   });
-
+  
+  sample({
+    clock: $timeout,
+    target: [cleanupFx, timeoutFx],
+  });
+  
   return {
     tick,
     isRunning: $isRunning,


### PR DESCRIPTION
Description
мелкая правка баги, если в interval менять параметр timeout, при уже включенном start. То setTimeout не переопределялся и работал на прошлому заданному timeout